### PR TITLE
fix: generate error should fail CI (resolves #37)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"dev": "nuxt",
 		"build": "nuxt build",
 		"start": "nuxt start",
-		"generate": "nuxt generate",
+		"generate": "nuxt generate --fail-on-error",
 		"lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
 		"lint:fix": "eslint --ext .js,.vue --ignore-path .gitignore . --fix",
 		"test": "npm run lint"


### PR DESCRIPTION
This PR adds the `--fail-on-error` flag to the generate command, which will cause the build to fail if any errors occur during the static site generation process.