### PR TITLE
feat: add Fira Sans webfont (resolves #77)

### DIFF
--- a/assets/css/abstracts/_abstracts.scss
+++ b/assets/css/abstracts/_abstracts.scss
@@ -1,1 +1,2 @@
 // Abstract styles.
+@import "variables";

--- a/assets/css/abstracts/_variables.scss
+++ b/assets/css/abstracts/_variables.scss
@@ -1,0 +1,2 @@
+// Typography
+$family-sans-serif: "Fira Sans", sans-serif;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,7 +1,11 @@
-@import "~bulma/sass/utilities/_all";
+/**
+ * Bulma Customizations are made in abstracts/_variables.scss
+ *
+ * @see: https://bulma.io/documentation/customize/variables/
+ */
+@import "abstracts/abstracts";
 
-/** Bulma Customizations **/
-
+/** Bulma **/
 @import "~bulma";
 
 /** Partials **/
@@ -11,5 +15,4 @@
 @import "layout/layout";
 @import "pages/pages";
 @import "themes/themes";
-@import "abstracts/abstracts";
 @import "vendors/vendors";

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -90,8 +90,14 @@ export default {
 		"@nuxtjs/pwa",
 		// Doc: https://github.com/nuxt-community/dotenv-module
 		"@nuxtjs/dotenv",
-		"@nuxtjs/style-resources"
+		"@nuxtjs/style-resources",
+		"nuxt-webfontloader"
 	],
+	webfontloader: {
+		google: {
+			families: ["Fira+Sans:400,400i,500,600,700&display=swap"]
+		}
+	},
 	/*
 	** Axios module configuration
 	** See https://axios.nuxtjs.org/options

--- a/package-lock.json
+++ b/package-lock.json
@@ -9895,6 +9895,15 @@
 				"@nuxt/webpack": "2.11.0"
 			}
 		},
+		"nuxt-webfontloader": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/nuxt-webfontloader/-/nuxt-webfontloader-1.1.0.tgz",
+			"integrity": "sha512-GyDgABmI0Oq54s2tA9SZC28TmHy2xGdWSXrfcGPPfDBVhgQQlGL5CJcAlvovcuhefzzZrzGgs35HIcv5qym4fQ==",
+			"dev": true,
+			"requires": {
+				"webfontloader": "^1.6.28"
+			}
+		},
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -15285,6 +15294,12 @@
 					}
 				}
 			}
+		},
+		"webfontloader": {
+			"version": "1.6.28",
+			"resolved": "https://registry.npmjs.org/webfontloader/-/webfontloader-1.6.28.tgz",
+			"integrity": "sha1-23hhKSU8tujq5UwvsF+HCvZnW64=",
+			"dev": true
 		},
 		"webpack": {
 			"version": "4.41.3",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"markdownlint-cli": "^0.22.0",
 		"node-sass": "^4.13.1",
 		"npm-run-all": "^4.1.5",
+		"nuxt-webfontloader": "^1.1.0",
 		"sass-loader": "^8.0.2",
 		"stylelint": "^13.2.0",
 		"stylelint-config-recommended-scss": "^4.2.0",


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run dev` and reviewing affected routes
* [x] This pull request has been built by running `npm run generate` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This PR uses [nuxt-webfontloader](https://github.com/Developmint/nuxt-webfontloader) to add the Fira Sans webfont and applies it by setting the `$family-sans-serif` [initial variable](https://bulma.io/documentation/customize/variables/#initial-variables) for Bulma.

## Steps to test

1. Visit the deploy preview.

**Expected behavior:** Fira Sans is used throughout the site.

## Additional information

- https://github.com/Developmint/nuxt-webfontloader#adding-google-fonts-with-font-display-option
- https://bulma.io/documentation/customize/variables/#initial-variables

## Related issues

- Resolves #77.
