### PR TITLE
feat: reduce the use of routes in config

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -30,15 +30,15 @@ export default {
 
 					const postRoutes = []
 
-					if (totalPages > 1) {
-						posts.data.map((...post) => {
-							postRoutes.push({ route: `/news-and-views/${post.slug}`, payload: post })
-						})
-					} else {
-						posts.data.map((post) => {
-							postRoutes.push({ route: `/news-and-views/${post.slug}`, payload: post })
-						})
-					}
+					// if (totalPages > 1) {
+					// 	posts.data.map((...post) => {
+					// 		postRoutes.push({ route: `/news-and-views/${post.slug}`, payload: post })
+					// 	})
+					// } else {
+					// 	posts.data.map((post) => {
+					// 		postRoutes.push({ route: `/news-and-views/${post.slug}`, payload: post })
+					// 	})
+					// }
 
 					callback(null, [...newsPaginationRoutes, ...postRoutes])
 				}))

--- a/pages/news-and-views/_slug/index.vue
+++ b/pages/news-and-views/_slug/index.vue
@@ -1,8 +1,10 @@
 <template>
-	<PostArticle :title="Title" :content="Content" :picture="Picture" :tags="Tags" />
+	<PostArticle :title="title" :content="content" :picture="picture" :tags="tags" />
 </template>
 
 <script>
+import axios from "axios"
+import Config from "~/assets/config"
 import PostArticle from "~/components/PostArticle"
 export default {
 	async validate ({ params, store }) {
@@ -12,11 +14,11 @@ export default {
 		const linkList = store.state.posts.map(({ slug }) => slug)
 		return linkList.includes(params.slug)
 	},
-	head () {
-		return {
-			title: this.Title
-		}
-	},
+	// head () {
+	// 	return {
+	// 		title: this.Title
+	// 	}
+	// },
 	components: {
 		PostArticle
 	},
@@ -24,25 +26,45 @@ export default {
 		return {
 		}
 	},
-	computed: {
-		links () {
-			return this.$store.state.posts.map(({ slug }) => slug)
-		},
-		linkNames () {
-			return this.links.map(x => x.replace(/-/g, " "))
-		},
-		Title () {
-			return this.$store.state.posts.find(post => post.slug === this.$route.params.slug).title
-		},
-		Picture () {
-			return this.$store.state.posts.find(post => post.slug === this.$route.params.slug).picture
-		},
-		Content () {
-			return this.$store.state.posts.find(post => post.slug === this.$route.params.slug).content
-		},
-		Tags () {
-			return this.$store.state.posts.find(post => post.slug === this.$route.params.slug).tags
-		}
+	// computed: {
+	// 	links () {
+	// 		return this.$store.state.posts.map(({ slug }) => slug)
+	// 	},
+	// 	linkNames () {
+	// 		return this.links.map(x => x.replace(/-/g, " "))
+	// 	},
+	// 	Title () {
+	// 		return this.$store.state.posts.find(post => post.slug === this.$route.params.slug).title
+	// 	},
+	// 	Picture () {
+	// 		return this.$store.state.posts.find(post => post.slug === this.$route.params.slug).picture
+	// 	},
+	// 	Content () {
+	// 		return this.$store.state.posts.find(post => post.slug === this.$route.params.slug).content
+	// 	},
+	// 	Tags () {
+	// 		return this.$store.state.posts.find(post => post.slug === this.$route.params.slug).tags
+	// 	}
+	// },
+	asyncData (context) {
+		return axios.get(`${Config.wpDomain}${Config.apiBase}posts`).then((response) => {
+			const res = response.data.filter(x => x.slug === context.params.slug)[0]
+			let picture = "https://wecount.inclusivedesign.ca/wp-content/uploads/2019/10/We-Count-logos_colour-and-bw-01.png"
+			// let altTag = ""
+			if (res._links["wp:featuredmedia"] !== undefined) {
+				const api = res._links["wp:featuredmedia"][0].href
+				const pic = axios.get(api)
+				picture = pic.source_url
+				// altTag = pic.data.alt_text
+			}
+			return {
+				title: res.title.rendered,
+				content: res.content.rendered,
+				picture,
+				tags: res.pure_taxonomies.tags.map(({ name }) => name)
+
+			}
+		})
 	}
 }
 </script>

--- a/pages/news-and-views/_slug/index.vue
+++ b/pages/news-and-views/_slug/index.vue
@@ -48,19 +48,17 @@ export default {
 	// },
 	asyncData (context) {
 		return axios.get(`${Config.wpDomain}${Config.apiBase}posts`).then((response) => {
-			const res = response.data.filter(x => x.slug === context.params.slug)[0]
-			let picture = "https://wecount.inclusivedesign.ca/wp-content/uploads/2019/10/We-Count-logos_colour-and-bw-01.png"
+			const defaultPicture = "https://wecount.inclusivedesign.ca/wp-content/uploads/2019/10/We-Count-logos_colour-and-bw-01.png"
+			const res = response.data.filter(post => post.slug === context.params.slug)[0]
 			// let altTag = ""
-			if (res._links["wp:featuredmedia"] !== undefined) {
-				const api = res._links["wp:featuredmedia"][0].href
-				const pic = axios.get(api)
-				picture = pic.source_url
-				// altTag = pic.data.alt_text
-			}
+			const api = res._links["wp:featuredmedia"][0].href
+			const pic = axios.get(api)
+			const picture = pic.source_url
+			// altTag = pic.data.alt_text
 			return {
 				title: res.title.rendered,
 				content: res.content.rendered,
-				picture,
+				picture: picture || defaultPicture,
 				tags: res.pure_taxonomies.tags.map(({ name }) => name)
 
 			}


### PR DESCRIPTION
* [ ] This pull request has been linted by running `npm run lint` without errors
* [ ] This pull request has been tested by running `npm run dev` and reviewing affected routes
* [ ] This pull request has been built by running `npm run generate` without errors
* [ ] This isn't a duplicate of an existing pull request

## Description

Proof of concept for generating posts without defining routes in nuxt.config.js

## Steps to test

1. click through pages
2. make sure nothing has broken

**Expected behavior:** <!-- What should happen -->

Nothing breaks

## Additional information

Just like PR #105 when running `npm run generate` the pages created by `pages/news-and-views/_slug.vue/index.vue` does not appear in the cli result message but you are able to reach them after deploying
```
ℹ Generating pages                                                                                                                                                                                                      19:11:22
✔ Generated /                                                                                                                                                                                                           19:11:23
✔ Generated /news-and-views                                                                                                                                                                                             19:11:25
✔ Generated /news-and-views/page/1    
```
<!-- Please provide any additional information that can help us review your contribution. -->

## Related issues

resolves #105 