### PR TITLE
Issue-131: Clicking a site page link on the search result now leads to the actual page

### DIFF
--- a/pages/search/_query/index.vue
+++ b/pages/search/_query/index.vue
@@ -1,12 +1,12 @@
 <template>
-	<div class="container">
+	<article>
 		<h1 class="title">
 			Search: “{{ searchQuery }}”
 		</h1>
 		<p>We found {{ searchResults.length }} results for your search.</p>
 		<NewsGrid :postList="pagePostList[$route.query.page ? parseInt($route.query.page) - 1 : 0]" />
 		<Pagination v-if="pageCount > 1" :pageLinks="pageLinks" :currentPageNum="$route.query.page ? parseInt($route.query.page) : 1" />
-	</div>
+	</article>
 </template>
 
 <script>

--- a/shared/DataFetcher.js
+++ b/shared/DataFetcher.js
@@ -1,13 +1,15 @@
 import axios from "axios"
 import Config from "../assets/config"
+import Utils from "./Utils"
 
+// Share data fetch functions
 export default {
 	async categorizedItems (categoryType, categoryId) {
 		// The fuction to process returned data from the Wordpress API
 		const processItems = function (items) {
 			return items.map(function (oneItem) {
 				// Strip html tags to get pure text for the content preview
-				const previewContent = oneItem.content.rendered.replace(/<\/?[^>]+(>|$)/g, "")
+				const previewContent = Utils.stripHtmlTags(oneItem.content.rendered)
 
 				return {
 					slug: oneItem.slug,
@@ -61,16 +63,19 @@ export default {
 		const pageAPI = Config.wpDomain + Config.apiBase + "pages?per_page=100"
 
 		const response = await axios.get(`${pageAPI}`)
-		const results = []
 
-		response.data.map(function (onePage) {
-			const structuredItem = {
+		return response.data.map(function (onePage) {
+			// Strip html tags to get pure text for the content preview
+			const previewContent = Utils.stripHtmlTags(onePage.content.rendered)
+
+			return {
 				slug: onePage.slug,
 				title: onePage.title.rendered,
-				content: onePage.content.rendered
+				content: onePage.content.rendered,
+				href: "/" + onePage.slug + "/",
+				isExternalHref: false,
+				previewContent
 			}
-			results.push(structuredItem)
 		})
-		return results
 	}
 }

--- a/shared/Utils.js
+++ b/shared/Utils.js
@@ -1,0 +1,7 @@
+// Shared utility functons
+
+export default {
+	stripHtmlTags (inputString) {
+		return inputString.replace(/<\/?[^>]+(>|$)/g, "")
+	}
+}


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run dev` and reviewing affected routes
* [X] This pull request has been built by running `npm run generate` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

To resolve https://github.com/inclusive-design/wecount.inclusivedesign.ca/issues/131.
Clicking a site page link on the search result now leads to the actual page

## Steps to test

Follow steps described in https://github.com/inclusive-design/wecount.inclusivedesign.ca/issues/131 to reproduce the problem

**Expected behavior:** <!-- What should happen -->

The problem should be fixed: Clicking a site page link on the search result now leads to the actual page.