### PR TITLE
fix: swap categories for News and Views

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -6,7 +6,7 @@ export default {
 	generate: {
 		fallback: true,
 		async routes (callback) {
-			const viewsAPI = Config.wpDomain + Config.apiBase + "posts?categories=8"
+			const viewsAPI = Config.wpDomain + Config.apiBase + "posts?categories=1"
 			// Determine how many pages of posts are available
 			const totalPages = await (await axios.get(`${viewsAPI}`)).headers["x-wp-totalpages"]
 			// Create empty array to hold all retrieved post data in chunks of 10

--- a/store/actions.js
+++ b/store/actions.js
@@ -4,7 +4,7 @@ export default {
 	fetchNews: async (context) => {
 		// Only fetch data one time when the site is up. The same data will be re-used.
 		if (!context.state.isNewsFetched) {
-			const news = await DataFetcher.categorizedItems("news", 1)
+			const news = await DataFetcher.categorizedItems("news", 8)
 			context.commit("setNews", news)
 		}
 	},
@@ -13,7 +13,7 @@ export default {
 		// Only fetch at the first time since the website works with a static set of data. Any data change
 		// will trigger the website to be re-deployed.
 		if (!context.state.isViewsFetched) {
-			const views = await DataFetcher.categorizedItems("views", 8)
+			const views = await DataFetcher.categorizedItems("views", 1)
 			context.commit("setViews", views)
 		}
 	},


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run dev` and reviewing affected routes
* [x] This pull request has been built by running `npm run generate` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

WordPress uses a default category (ID: 1) for new posts. When I added the COVID-19 response post I realized that we set up the default category as "News". I think the default category should be "Views". So I've edited the categories in the CMS to change ID 1 to "Views" and ID 8 to "News". This pull request makes the corresponding change in Nuxt.

## Steps to test

1. Visit News and Views pages.

**Expected behavior:** See "The Importance of Peripheral Vision" and "Continuing Our Work During COVID-19" on Views. See other posts on "News".

## Additional information

Not applicable.

## Related issues

Not applicable.
