### PR TITLE
fix: add ARIA role to search results message (fixes #173)

### DIFF
--- a/pages/search/_query/index.vue
+++ b/pages/search/_query/index.vue
@@ -3,7 +3,9 @@
 		<h1 class="title">
 			Search: “{{ searchQuery }}”
 		</h1>
-		<p>We found {{ searchResults.length }} results for your search.</p>
+		<p role="status">
+			We found {{ searchResults.length }} results for your search.
+		</p>
 		<NewsGrid :postList="pagePostList[$route.query.page ? parseInt($route.query.page) - 1 : 0]" />
 		<Pagination v-if="pageCount > 1" :pageLinks="pageLinks" :currentPageNum="currentPageNum" />
 	</article>


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run dev` and reviewing affected routes
* [x] This pull request has been built by running `npm run generate` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Adds the appropriate ARIA role to search results message.

## Steps to test

1. Perform a search.

**Expected behavior:** The paragraph that communicates how many results were found includes the `role="status"` attribute.

## Additional information

Not applicable.

## Related issues

Resolves #173.
