### PR TITLE
feat: use excerpts from WordPress API (resolves #172)

### DIFF
--- a/components/NewsGrid.vue
+++ b/components/NewsGrid.vue
@@ -7,7 +7,7 @@
 				:altTag="post.altTag"
 				:title="post.title"
 				:author="post.author"
-				:previewContent="post.previewContent"
+				:excerpt="post.excerpt"
 				:date="post.date"
 				:dateTime="post.dateTime"
 				:href="post.href"

--- a/components/NewsItem.vue
+++ b/components/NewsItem.vue
@@ -13,7 +13,7 @@
 		<div class="date">
 			<time :datetime="dateTime">{{ date }}</time>
 		</div>
-		<div v-html="previewContent" class="preview-content" />
+		<div v-html="excerpt" class="preview-content" />
 	</article>
 </template>
 
@@ -41,7 +41,7 @@ export default {
 			type: String,
 			default: ""
 		},
-		previewContent: {
+		excerpt: {
 			type: String,
 			default: ""
 		},

--- a/shared/DataFetcher.js
+++ b/shared/DataFetcher.js
@@ -8,14 +8,13 @@ export default {
 		// The fuction to process returned data from the Wordpress API
 		const processItems = function (items) {
 			return items.map(function (oneItem) {
-				// Strip html tags to get pure text for the content preview
-				const previewContent = Utils.stripHtmlTags(oneItem.content.rendered)
-
 				return {
 					slug: oneItem.slug,
 					title: oneItem.title.rendered,
 					author: oneItem._embedded.author[0].name,
 					content: oneItem.content.rendered,
+					// Strip html tags to get pure text for the content preview
+					excerpt: Utils.stripHtmlTags(oneItem.excerpt.rendered),
 					date: new Date(oneItem.date).toLocaleString("en-us", {
 						year: "numeric",
 						month: "long",
@@ -28,8 +27,7 @@ export default {
 					// For news, "href" points to the external news links. For views, "href" is customized to show views content.
 					href: categoryType === "news" ? oneItem.acf.link : "/views/" + oneItem.slug,
 					isExternalHref: categoryType === "news",
-					showPreviewImage: categoryType !== "news",
-					previewContent
+					showPreviewImage: categoryType !== "news"
 				}
 			})
 		}
@@ -65,16 +63,14 @@ export default {
 		const response = await axios.get(`${pageAPI}`)
 
 		return response.data.map(function (onePage) {
-			// Strip html tags to get pure text for the content preview
-			const previewContent = Utils.stripHtmlTags(onePage.content.rendered)
-
 			return {
 				slug: onePage.slug,
 				title: onePage.title.rendered,
 				content: onePage.content.rendered,
+				// Strip html tags to get pure text for the content preview
+				excerpt: Utils.stripHtmlTags(onePage.content.rendered),
 				href: "/" + onePage.slug + "/",
-				isExternalHref: false,
-				previewContent
+				isExternalHref: false
 			}
 		})
 	}


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run dev` and reviewing affected routes
* [x] This pull request has been built by running `npm run generate` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This PR uses the custom WordPress excerpt for post previews in the `<NewsItem />` component.

## Steps to test

1. Identify a WordPress post with a custom excerpt, e.g. https://wecount-cms.inclusivedesign.ca/wp-json/wp/v2/posts/210.
2. Find it on the Views page.

**Expected behavior:** The excerpt shown in the API is used for the preview text in the grid.

## Additional information

- https://wordpress.org/support/article/excerpt/

## Related issues

Resolves #172.
