### PR TITLE
Issue-177: Not to show the tag area when there's no tags.

### DIFF
--- a/components/PostArticle.vue
+++ b/components/PostArticle.vue
@@ -8,7 +8,7 @@
 
 		<div v-html="postToRender.content" class="api-content" />
 
-		<section class="tags-info">
+		<section v-if="postToRender.tags.length > 0" class="tags-info">
 			<h3>Active Tags</h3>
 			<div class="tags">
 				<nuxt-link v-for="(t, index) in postToRender.tags" :key="index" :to="{ path: '/tag', query: { s: t }}">


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run dev` and reviewing affected routes
* [X] This pull request has been built by running `npm run generate` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

The tag area on single views page should only show when there are tags.

## Steps to test

Since the WordPress API for the development is not set up yet and all views posts production data have tags. The test step is by modifying the data fetcher component:

1. Checkout this branch;
2. Modify [this line](https://github.com/cindyli/wecount.inclusivedesign.ca/blob/fix/when-no-tags/shared/DataFetcher.js#L24) to `tags: [],`;
3. In a terminal, run "npm run dev" to start the site locally;
4. Go to "Views" -> select a single article;
5. The tags area underneath the article content should not show.

6. Undo the modification at step 2;
7. Go to "Views" -> select a single article;
8. The tags area underneath the article content should show.

**Expected behavior:** 

See above.
