### PR TITLE
fix: resolve broken Netlify link

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -59,9 +59,7 @@
 			<Funders />
 		</div>
 		<p class="netlify-notice">
-			Hosted with <nuxt-link to="https://netlify.com">
-				Netlify
-			</nuxt-link>
+			Hosted with <a rel="external nofollower noopener" href="https://netlify.com">Netlify</a>
 		</p>
 	</footer>
 </template>


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run dev` and reviewing affected routes
* [x] This pull request has been built by running `npm run generate` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Using a `<nuxt-link>` for the Netlify credit broke the link. This PR uses a standard `<a>` link.

## Steps to test

1. Visit deploy preview.
2. Follow the link to Netlify.

**Expected behavior:** It works.

## Additional information

Not applicable.

## Related issues

Not applicable.
