### PR TITLE
feat: configure PostCSS/Autoprefixer (resolves #188)

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,3 @@
+# Browsers that we support
+
+> 1%

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -102,10 +102,10 @@ export default {
 	** Build configuration
 	*/
 	build: {
-		/*
-		** You can extend webpack config here
-		*/
-		extend (config, ctx) {
+		postcss: {
+			preset: {
+				browsers: "> 1%"
+			}
 		}
 	}
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -102,10 +102,10 @@ export default {
 	** Build configuration
 	*/
 	build: {
-		postcss: {
-			preset: {
-				browsers: "> 1%"
-			}
+		/*
+		** You can extend webpack config here
+		*/
+		extend (config, ctx) {
 		}
 	}
 }


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run dev` and reviewing affected routes
* [x] This pull request has been built by running `npm run generate` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Adds a `.browserslistrc` file which will be used by [PostCSS](https://nuxtjs.org/api/configuration-build/#postcss).

## Steps to test

1. From the project root, run `npx browserslist`.

**Expected behavior:** List of browsers should match [our desired configuration](https://browserl.ist/?q=%3E+1%25).

## Additional information

Why not use 'browsers' in `preset` config? https://github.com/csstools/postcss-preset-env#browsers

> The `browsers` option should only be used when a standard browserslist configuration is not available.

## Related issues
- Resolves #188.
