### PR TITLE
Issue-170: Auto generate navigation menus based on the API response.

### DIFF
--- a/assets/css/layout/_footer.scss
+++ b/assets/css/layout/_footer.scss
@@ -165,7 +165,7 @@ footer {
 
 				ul {
 					display: grid;
-					grid-template-columns: repeat(4, auto);
+					grid-template-columns: repeat(3, auto);
 
 					li {
 						margin-bottom: rem(36);
@@ -181,17 +181,12 @@ footer {
 						grid-column: 2/3;
 					}
 
-					li:nth-child(4) {
+					li:nth-child(4),
+					li:nth-child(5) {
 						grid-column: 3/4;
 					}
 
-					li:nth-child(5),
-					li:nth-child(6),
-					li:nth-child(7) {
-						grid-column: 4/5;
-					}
-
-					li:nth-last-child(-n+5):not(:last-child) {
+					li:nth-last-child(-n+3) {
 						margin-top: rem(-64);
 					}
 				}

--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -4,49 +4,11 @@
 			<!-- TODO: Remove style attribute. -->
 			<nav aria-label="Footer" class="footer-nav" style="display: none;">
 				<ul>
-					<li>
+					<li v-for="menuItem in navMenu" :key="menuItem.slug">
 						<!-- Adding "exact" to make sure "nuxt-link-active" class only applies to the current selected link -->
 						<!-- See https://github.com/nuxt/nuxt.js/issues/2214 -->
-						<nuxt-link to="/" exact>
-							Home
-						</nuxt-link>
-					</li>
-
-					<li>
-						<nuxt-link to="/about/" exact>
-							About
-						</nuxt-link>
-					</li>
-
-					<li>
-						<!-- TODO: Remove style attribute. -->
-						<nuxt-link to="/tools/" style="display: none;" exact>
-							Tools
-						</nuxt-link>
-					</li>
-
-					<li>
-						<nuxt-link to="/inclusion-challenges/" exact>
-							Inclusion Challenges
-						</nuxt-link>
-					</li>
-
-					<li>
-						<!-- TODO: Remove style attribute. -->
-						<nuxt-link to="/our-data/" style="display: none;" exact>
-							Our Data
-						</nuxt-link>
-					</li>
-
-					<li>
-						<nuxt-link to="/news/" exact>
-							News
-						</nuxt-link>
-					</li>
-
-					<li>
-						<nuxt-link to="/views/" exact>
-							Views
+						<nuxt-link :to="menuItem.href" exact>
+							{{ menuItem.title }}
 						</nuxt-link>
 					</li>
 				</ul>
@@ -65,19 +27,21 @@
 </template>
 
 <script>
+import Utils from "~/shared/Utils";
 import ContactInfo from "~/components/ContactInfo";
 import SocialMedia from "~/components/SocialMedia";
 import Funders from "~/components/Funders";
+
 export default {
 	components: {
 		ContactInfo,
 		SocialMedia,
 		Funders
 	},
-	data () {
-		return {
-			today: new Date()
-		};
+	computed: {
+		navMenu () {
+			return Utils.generateNavMenu(this.$store.state.sitePages, true);
+		}
 	}
 };
 </script>

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -6,7 +6,7 @@
 				<button id="menuToggleButton" @click="toggleNavMenu()" aria-expanded="false">
 					<MenuIcon />&nbsp;Menu
 				</button>
-				<NavBar />
+				<NavBar :navMenu="navMenu" />
 				<SearchForm />
 			</div>
 		</div>
@@ -14,8 +14,7 @@
 </template>
 
 <script>
-// TODO
-// Want to make this more of a modal
+import Utils from "~/shared/Utils";
 import Brand from "~/components/Brand";
 import NavBar from "~/components/NavBar";
 import SearchForm from "~/components/SearchForm";
@@ -28,13 +27,10 @@ export default {
 		SearchForm,
 		MenuIcon
 	},
-	data () {
-		return {
-			// Used on the mobile design to determine whether the navigation menu should be shown.
-			// Set to true when a user clicks on the "menu" icon to see the navigation menu.
-			// Set to false when a user clicks on the "menu" icon again to hide the navigation menu.
-			showMenu: false
-		};
+	computed: {
+		navMenu () {
+			return Utils.generateNavMenu(this.$store.state.sitePages);
+		}
 	},
 	mounted () {
 		// Attach the DOM listener that closes the navigation menu when the user clicks on anywhere

--- a/components/NavBar.vue
+++ b/components/NavBar.vue
@@ -1,22 +1,18 @@
 <template>
 	<nav class="nav-bar">
-		<nuxt-link to="/about/">
-			About
-		</nuxt-link>
-		<nuxt-link to="/tools/" style="display: none;">
-			Tools
-		</nuxt-link>
-		<nuxt-link to="/inclusion-challenges/">
-			Inclusion Challenges
-		</nuxt-link>
-		<nuxt-link to="/our-data/" style="display: none;">
-			Our Data
-		</nuxt-link>
-		<nuxt-link to="/news/">
-			News
-		</nuxt-link>
-		<nuxt-link to="/views/">
-			Views
+		<nuxt-link v-for="menuItem in navMenu" :key="menuItem.slug" :to="menuItem.href">
+			{{ menuItem.title }}
 		</nuxt-link>
 	</nav>
 </template>
+
+<script>
+export default {
+	props: {
+		navMenu: {
+			type: Array,
+			default: () => []
+		}
+	}
+};
+</script>

--- a/shared/DataFetcher.js
+++ b/shared/DataFetcher.js
@@ -58,7 +58,7 @@ export default {
 	async sitePages () {
 		// According to the Wordpress API for pagination and embedding: https://developer.wordpress.org/rest-api/using-the-rest-api/pagination/,
 		// fetch 100 records per page (the maxium number per page supported by Wordpress) to fasten the query
-		const pageAPI = Config.wpDomain + Config.apiBase + "pages?per_page=100";
+		const pageAPI = Config.wpDomain + Config.apiBase + "pages?per_page=100&order=asc&orderby=menu_order";
 
 		const response = await axios.get(`${pageAPI}`);
 
@@ -69,6 +69,7 @@ export default {
 				content: onePage.content.rendered,
 				// Strip html tags to get pure text for the content preview
 				excerpt: Utils.stripHtmlTags(onePage.content.rendered),
+				menu_order: onePage.menu_order,
 				href: "/" + onePage.slug + "/",
 				isExternalHref: false
 			};

--- a/shared/Utils.js
+++ b/shared/Utils.js
@@ -6,11 +6,11 @@ export default {
 	},
 
 	/**
-	 * The complete Triforce, or one or more components of the Triforce.
-	 * @typedef {Object} menuItem
-	 * @property {String} slug - The slug of the corresponding page that the menu item lands on.
-	 * @property {String} title - The title of the corresponding page that the menu item lands on.
-	 * @property {String} href - The href to direct the menu item to its corresponding page.
+	 * generateNavMenu() returns an array of menu items. The structure of a menu item is:
+	 * @typedef {Object} MenuItem
+	 * @property {string} slug - The slug of the corresponding page that the menu item lands on.
+	 * @property {string} title - The title of the corresponding page that the menu item lands on.
+	 * @property {string} href - The href to direct the menu item to its corresponding page.
 	 */
 
 	/**
@@ -18,14 +18,17 @@ export default {
 	 * The retun menu array will:
 	 * 1. Exclude all pages that have menu_order === 0;
 	 * 2. Append "News" and "Views" menu items to the end.
-	 * @param {Array<Object>} sitePages - All menu pages sorted by menu_order.
-	 * @param {Boolean} includeHomeItem - A flag indicating if the home menu item should be included.
-	 * @return {Array<menuItem>} An array of object including the slug, menu title and href.
+	 * @param {array<Object>} sitePages - All menu pages sorted by menu_order.
+	 * @param {boolean} includeHomeItem - A flag indicating if the home menu item should be included.
+	 * @return {array<MenuItem>} An array of object including the slug, menu title and href.
 	 */
 	generateNavMenu (sitePages, includeHomeItem) {
 		const menuItems = [];
 		const homeMenuItem = [];
-		const itemsToAppend = [{
+		// Since "News" and "Views" don't have landing pages defined at the WP back-end, these menu items need to
+		// be explicitly appended to the nav menu. Using "append" is because they are the last 2 nav elements according
+		// to the design.
+		const extraMenuItemsToAppend = [{
 			slug: "news",
 			title: "News",
 			href: "/news"
@@ -45,7 +48,7 @@ export default {
 			}
 
 			// Exclude pages that have menu_order === 0, which indicates the page should not be displayed on the header nav menu.
-			if (oneSitePage.menu_order) {
+			if (oneSitePage.menu_order !== 0) {
 				menuItems.push({
 					slug: oneSitePage.slug,
 					title: oneSitePage.title,
@@ -54,6 +57,6 @@ export default {
 			}
 		});
 
-		return [...homeMenuItem, ...menuItems, ...itemsToAppend];
+		return [...homeMenuItem, ...menuItems, ...extraMenuItemsToAppend];
 	}
 };

--- a/shared/Utils.js
+++ b/shared/Utils.js
@@ -40,6 +40,9 @@ export default {
 
 		sitePages.forEach((oneSitePage) => {
 			if (includeHomeItem && oneSitePage.slug === "home" && oneSitePage.menu_order === 0) {
+				// The title "Home" is hardcoded based on the slug is because the title received from the API response is
+				// `Creating an inclusive data ecosystem`, which doesn't provide any hint that it's a home page. And it also
+				// doesn't match what's on the design.
 				homeMenuItem.push({
 					slug: oneSitePage.slug,
 					title: "Home",

--- a/shared/Utils.js
+++ b/shared/Utils.js
@@ -6,17 +6,23 @@ export default {
 	},
 
 	/**
+	 * The complete Triforce, or one or more components of the Triforce.
+	 * @typedef {Object} menuItem
+	 * @property {String} slug - The slug of the corresponding page that the menu item lands on.
+	 * @property {String} title - The title of the corresponding page that the menu item lands on.
+	 * @property {String} href - The href to direct the menu item to its corresponding page.
+	 */
+
+	/**
 	 * Generate the navigation menu based on the response from the Wordpress API.
 	 * The retun menu array will:
-	 * 1. Exclude all pages whose menu_order === 0;
+	 * 1. Exclude all pages that have menu_order === 0;
 	 * 2. Append "News" and "Views" menu items to the end.
 	 * @param {Array<Object>} sitePages - All menu pages sorted by menu_order.
 	 * @param {Boolean} includeHomeItem - A flag indicating if the home menu item should be included.
-	 * @return {Array<Object>} An array of object including the slug, menu title and href.
+	 * @return {Array<menuItem>} An array of object including the slug, menu title and href.
 	 */
 	generateNavMenu (sitePages, includeHomeItem) {
-		// Don't include the menu item for "home" by default
-		includeHomeItem = includeHomeItem === undefined ? false : includeHomeItem;
 		const menuItems = [];
 		const homeMenuItem = [];
 		const itemsToAppend = [{
@@ -30,7 +36,7 @@ export default {
 		}];
 
 		sitePages.forEach((oneSitePage) => {
-			if (includeHomeItem && oneSitePage.slug === "home") {
+			if (includeHomeItem && oneSitePage.slug === "home" && oneSitePage.menu_order === 0) {
 				homeMenuItem.push({
 					slug: oneSitePage.slug,
 					title: "Home",
@@ -38,7 +44,8 @@ export default {
 				});
 			}
 
-			if (oneSitePage.menu_order > 0) {
+			// Exclude pages that have menu_order === 0, which indicates the page should not be displayed on the header nav menu.
+			if (oneSitePage.menu_order) {
 				menuItems.push({
 					slug: oneSitePage.slug,
 					title: oneSitePage.title,

--- a/shared/Utils.js
+++ b/shared/Utils.js
@@ -3,5 +3,50 @@
 export default {
 	stripHtmlTags (inputString) {
 		return inputString.replace(/<\/?[^>]+(>|$)/g, "");
+	},
+
+	/**
+	 * Generate the navigation menu based on the response from the Wordpress API.
+	 * The retun menu array will:
+	 * 1. Exclude all pages whose menu_order === 0;
+	 * 2. Append "News" and "Views" menu items to the end.
+	 * @param {Array<Object>} sitePages - All menu pages sorted by menu_order.
+	 * @param {Boolean} includeHomeItem - A flag indicating if the home menu item should be included.
+	 * @return {Array<Object>} An array of object including the slug, menu title and href.
+	 */
+	generateNavMenu (sitePages, includeHomeItem) {
+		// Don't include the menu item for "home" by default
+		includeHomeItem = includeHomeItem === undefined ? false : includeHomeItem;
+		const menuItems = [];
+		const homeMenuItem = [];
+		const itemsToAppend = [{
+			slug: "news",
+			title: "News",
+			href: "/news"
+		}, {
+			slug: "views",
+			title: "Views",
+			href: "/views"
+		}];
+
+		sitePages.forEach((oneSitePage) => {
+			if (includeHomeItem && oneSitePage.slug === "home") {
+				homeMenuItem.push({
+					slug: oneSitePage.slug,
+					title: "Home",
+					href: "/"
+				});
+			}
+
+			if (oneSitePage.menu_order > 0) {
+				menuItems.push({
+					slug: oneSitePage.slug,
+					title: oneSitePage.title,
+					href: "/" + oneSitePage.slug
+				});
+			}
+		});
+
+		return [...homeMenuItem, ...menuItems, ...itemsToAppend];
 	}
 };

--- a/store/actions.js
+++ b/store/actions.js
@@ -23,5 +23,9 @@ export default {
 			const sitePages = await DataFetcher.sitePages();
 			context.commit("setSitePages", sitePages);
 		}
+	},
+
+	nuxtServerInit ({ dispatch }) {
+		return dispatch("fetchSitePages");
 	}
 };


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run dev` and reviewing affected routes
* [X] This pull request has been built by running `npm run generate` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

To resolve https://github.com/inclusive-design/wecount.inclusivedesign.ca/issues/170.

Navigation menus on the header and footer are auto generated based on the WordPress API response.

## Steps to test

1. The navigation menu on the header shows 4 items: About, Inclusion Challenges, News, Views;
2. Remove `style="display: none;"` that hides the nav menu on the footer;
3. The nav menu on the footer shows 5 items: Home and 4 items described in 1.

The footer css has been adjusted to work with the current 5 menu items instead of 7 that was expected in the design. The footer css needs to be revisited every time when a menu item is added or removed.

**Expected behavior:** 

The navigation menu should look the same as what's in the current dev branch.