### PR TITLE
chore: add dedicated development endpoint for API (fix #166)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ nuxt generate
 ```
 
 The static website's files will be in the newly-created `dist` directory in the root of the project.
+To preview the static website, enter the following into your command line:
+
+```bash
+cd dist
+npx serve
+```
 
 ## How to Deploy
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ The static website's files will be in the newly-created `dist` directory in the 
 To preview the static website, enter the following into your command line:
 
 ```bash
-cd dist
-npx serve
+npx serve dist
 ```
 
 ## How to Deploy

--- a/assets/config.js
+++ b/assets/config.js
@@ -9,7 +9,7 @@ export default {
 	appThemeColor: "#ffffff",
 	appBgColor: "#ffffff",
 	appBaseUrl: "https://wecount.inclusivedesign.ca", // TODO: Figure out how to determine this at generate time.
-	wpDomain: (process.env.NODE_ENV === "production") ? "https://wecount-cms.inclusivedesign.ca" : "https://wecount-dev.inclusivedesign.ca",
+	wpDomain: (process.env.CONTEXT === "production") ? "https://wecount-cms.inclusivedesign.ca" : "https://wecount-dev.inclusivedesign.ca",
 	apiBase: "/wp-json/wp/v2/",
 	contactEmail: "wecount@inclusivedesign.ca",
 	// Using raw SVG content is to work around the issue with dynamically loading and injecting inline SVGs into the template.

--- a/assets/config.js
+++ b/assets/config.js
@@ -9,7 +9,7 @@ export default {
 	appThemeColor: "#ffffff",
 	appBgColor: "#ffffff",
 	appBaseUrl: "https://wecount.inclusivedesign.ca", // TODO: Figure out how to determine this at generate time.
-	wpDomain: "https://wecount-cms.inclusivedesign.ca",
+	wpDomain: (process.env.NODE_ENV === "production") ? "https://wecount-cms.inclusivedesign.ca" : "https://wecount-dev.inclusivedesign.ca",
 	apiBase: "/wp-json/wp/v2/",
 	contactEmail: "wecount@inclusivedesign.ca",
 	// Using raw SVG content is to work around the issue with dynamically loading and injecting inline SVGs into the template.


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run dev` and reviewing affected routes
* [x] This pull request has been built by running `npm run generate` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Now that https://wecount-dev.inclusivedesign.ca is set up, this PR configures all builds except for production builds to use this new dev endpoint.

## Steps to test

1. Edit some prominent content on https://wecount-dev.inclusivedesign.ca.
2. Run `npm run dev`.
3. Confirm that the edited content appears. 
4. Run `CONTEXT=production npm run generate`.
5. Run `npx serve dist` to preview the generated site.
6. Confirm that the content from https://wecount-cms.inclusivedesign.ca appears.

## Additional information

Not applicable.

## Related issues

- Resolves #166.