### PR TITLE
Add search to "Views" page

### DIFF
--- a/assets/css/components/_components.scss
+++ b/assets/css/components/_components.scss
@@ -5,3 +5,4 @@
 @import "cards";
 @import "aside";
 @import "post-article";
+@import "search";

--- a/assets/css/components/_news-and-views.scss
+++ b/assets/css/components/_news-and-views.scss
@@ -1,3 +1,23 @@
+.posts {
+	.search-container {
+		padding-bottom: rem(27);
+
+		form {
+			flex: 1;
+		}
+
+		input[type="search"] {
+			border: 1px solid $green-dark;
+			height: rem(41);
+			width: 100%;
+		}
+
+		::placeholder {
+			color: $green-dark;
+		}
+	}
+}
+
 .news-grid {
 	display: grid;
 	grid-gap: rem(30) rem(38);
@@ -69,6 +89,15 @@
 }
 
 @media screen and (min-width: 1024px) {
+	.posts {
+		.search-container {
+			input[type="search"] {
+				float: right;
+				width: rem(208);
+			}
+		}
+	}
+
 	.news-grid {
 		grid-template-columns: repeat(2, 1fr);
 

--- a/assets/css/components/_search.scss
+++ b/assets/css/components/_search.scss
@@ -1,0 +1,30 @@
+// Styles for the search container
+.search-container {
+	align-items: center;
+	display: flex;
+
+	input[type="search"] {
+		background-color: white;
+		background-image: url("../images/search.svg");
+		background-position: left rem(8) center;
+		background-repeat: no-repeat;
+		border: 0;
+		border-radius: rem(28);
+		outline: none;
+		padding: rem(16) rem(48);
+
+		&:focus {
+			background-position: left rem(8) center;
+			border-radius: rem(28);
+		}
+	}
+}
+
+@media screen and (min-width: 1024px) {
+	.search-container {
+		input[type="search"],
+		input[type="search"]:focus {
+			font-size: inherit;
+		}
+	}
+}

--- a/assets/css/layout/_header.scss
+++ b/assets/css/layout/_header.scss
@@ -74,19 +74,10 @@ header {
 				display: block;
 			}
 
-			// Styles for the search container
 			.search-container {
-				align-items: center;
-				display: flex;
-
 				input[type="search"] {
-					background-color: white;
-					background-image: url("../images/search.svg");
 					background-position: center;
-					background-repeat: no-repeat;
-					border: 0;
 					border-radius: 50%;
-					outline: none;
 					padding: rem(8) rem(16);
 					width: rem(16);
 
@@ -142,8 +133,7 @@ header {
 					input[type="search"]:focus {
 						background-position: left rem(8) center;
 						border-radius: rem(28);
-						font-size: inherit;
-						padding: rem(16) rem(48);
+						padding-left: rem(32);
 						width: rem(240);
 					}
 				}

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -7,7 +7,7 @@
 					<MenuIcon />&nbsp;Menu
 				</button>
 				<NavBar :navMenu="navMenu" />
-				<SearchForm />
+				<SearchForm :placeholder="placeholderForSerch" :ariaLabel="ariaLabelForSearch" />
 			</div>
 		</div>
 	</header>
@@ -26,6 +26,12 @@ export default {
 		NavBar,
 		SearchForm,
 		MenuIcon
+	},
+	data () {
+		return {
+			placeholderForSerch: "Search...",
+			ariaLabelForSearch: "Enter keywords for a site-wide search"
+		};
 	},
 	computed: {
 		navMenu () {

--- a/components/Posts.vue
+++ b/components/Posts.vue
@@ -1,6 +1,7 @@
 <template>
-	<article>
+	<article class="posts">
 		<h1>{{ title }}</h1>
+		<SearchForm v-if="title==='Views'" :placeholder="placeholderForSerch" :ariaLabel="ariaLabelForSearch" :context="searchContext" />
 		<NewsGrid :postList="postsChunksByPage[currentPageNum - 1]" />
 		<Pagination v-if="pageCount > 1" :pageLinks="pageLinks" :currentPageNum="currentPageNum" />
 	</article>
@@ -10,11 +11,13 @@
 import _ from "lodash";
 import Pagination from "~/components/Pagination";
 import NewsGrid from "~/components/NewsGrid";
+import SearchForm from "~/components/SearchForm";
 import Config from "~/assets/config.js";
 
 export default {
 	components: {
 		NewsGrid,
+		SearchForm,
 		Pagination
 	},
 	props: {
@@ -37,7 +40,10 @@ export default {
 	},
 	data () {
 		return {
-			numOfRecsPerPage: Config.numOfRecsPerPage
+			numOfRecsPerPage: Config.numOfRecsPerPage,
+			placeholderForSerch: "Search posts ...",
+			ariaLabelForSearch: "Enter keywords for a search in posts",
+			searchContext: "views"
 		};
 	},
 	computed: {

--- a/components/SearchForm.vue
+++ b/components/SearchForm.vue
@@ -1,12 +1,27 @@
 <template>
 	<div class="search-container">
 		<form id="search-form" action="/search">
-			<input
-				name="s"
-				type="search"
-				placeholder="Search..."
-				aria-label="Enter keywords for a site-wide search"
-			>
+			<input :placeholder="placeholder" :aria-label="ariaLabel" name="s" type="search">
+			<input :value="context" type="hidden" name="context">
 		</form>
 	</div>
 </template>
+
+<script>
+export default {
+	props: {
+		placeholder: {
+			type: String,
+			default: "Search..."
+		},
+		ariaLabel: {
+			type: String,
+			default: "Search"
+		},
+		context: {
+			type: String,
+			default: ""
+		}
+	}
+};
+</script>

--- a/pages/search/_query/index.vue
+++ b/pages/search/_query/index.vue
@@ -40,6 +40,9 @@ export default {
 		searchQuery () {
 			return decodeURIComponent(this.$route.query.s);
 		},
+		searchContext () {
+			return decodeURIComponent(this.$route.query.context);
+		},
 		currentPageNum () {
 			return this.$route.query.page ? parseInt(this.$route.query.page) : 1;
 		},
@@ -59,7 +62,7 @@ export default {
 			});
 		},
 		searchResults () {
-			return [...this.foundNews, ...this.foundViews, ...this.foundSitePages];
+			return this.searchContext === "views" ? this.foundViews : [...this.foundNews, ...this.foundViews, ...this.foundSitePages];
 		},
 		pageCount () {
 			return Math.ceil(this.searchResults.length / this.numOfRecsPerPage);


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run dev` and reviewing affected routes
* [X] This pull request has been built by running `npm run generate` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Add the search functionality to the "Views" page.

## Steps to test

1. Go to "Views" page
2. A search box shows at the top right corner. Its styling should match [the figma design](https://www.figma.com/file/0lcLol3X5MmOXackT2YbHJ/WeCount-website?node-id=239%3A0)
3. Enter a keyword in the search box, hit enter, the search result shows views post with the matched keyword
4. Search the same keyword using the search box in the header, the search result shows all matches across the site.

**Expected behavior:** 

The search via the search box on the "Views" page only searches thru views posts while the search using the search box on the header searches across the website.
