### PR TITLE
feat: differentiate WP domains for production deploy and other deploy

### DIFF
--- a/assets/config.js
+++ b/assets/config.js
@@ -9,7 +9,9 @@ export default {
 	appThemeColor: "#ffffff",
 	appBgColor: "#ffffff",
 	appBaseUrl: "https://wecount.inclusivedesign.ca", // TODO: Figure out how to determine this at generate time.
-	wpDomain: "https://wecount-cms.inclusivedesign.ca",
+	// The environment variable process.env.CONTEXT is the netlify deploy context. See https://docs.netlify.com/configure-builds/environment-variables/#build-metadata
+	// The Wordpress domain points to the production at the production deploy while it points to the dev Wordpress backend in other cases.
+	wpDomain: process.env.CONTEXT === "production" ? "https://wecount-cms.inclusivedesign.ca" : "https://wecount-dev.inclusivedesign.ca",
 	apiBase: "/wp-json/wp/v2/",
 	contactEmail: "wecount@inclusivedesign.ca",
 	// Using raw SVG content is to work around the issue with dynamically loading and injecting inline SVGs into the template.

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -4,6 +4,9 @@ import Utils from "./shared/Utils";
 
 export default {
 	mode: "universal",
+	env: {
+		CONTEXT: process.env.CONTEXT || "dev"
+	},
 	generate: {
 		fallback: true,
 		async routes () {


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run dev` and reviewing affected routes
* [X] This pull request has been built by running `npm run generate` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

To resolve https://github.com/inclusive-design/wecount.inclusivedesign.ca/issues/166.

The Wordpress domain will point to [the production WP domain](https://wecount-cms.inclusivedesign.ca) for the production deploy and point to [the development WP domain](https://wecount-dev.inclusivedesign.ca) for other deploy.

## Steps to test

Refer to the deploy preview of https://github.com/inclusive-design/wecount.inclusivedesign.ca/pull/204 for the testing. This preview uses the same method to point to [the development WP domain](https://wecount-dev.inclusivedesign.ca) while running this pull request in other environments uses the production WP.