### PR TITLE
fix: revert the auto generation of the navigation menu

### DIFF
--- a/assets/css/layout/_footer.scss
+++ b/assets/css/layout/_footer.scss
@@ -163,7 +163,7 @@ footer {
 
 				ul {
 					display: grid;
-					grid-template-columns: repeat(3, auto);
+					grid-template-columns: repeat(4, auto);
 
 					li {
 						margin-bottom: rem(36);
@@ -179,12 +179,17 @@ footer {
 						grid-column: 2/3;
 					}
 
-					li:nth-child(4),
-					li:nth-child(5) {
+					li:nth-child(4) {
 						grid-column: 3/4;
 					}
 
-					li:nth-last-child(-n+3) {
+					li:nth-child(5),
+					li:nth-child(6),
+					li:nth-child(7) {
+						grid-column: 4/5;
+					}
+
+					li:nth-last-child(-n+5):not(:last-child) {
 						margin-top: rem(-64);
 					}
 				}

--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -4,11 +4,49 @@
 			<!-- TODO: Remove style attribute. -->
 			<nav aria-label="Footer" class="footer-nav" style="display: none;">
 				<ul>
-					<li v-for="menuItem in navMenu" :key="menuItem.slug">
+					<li>
 						<!-- Adding "exact" to make sure "nuxt-link-active" class only applies to the current selected link -->
 						<!-- See https://github.com/nuxt/nuxt.js/issues/2214 -->
-						<nuxt-link :to="menuItem.href" exact>
-							{{ menuItem.title }}
+						<nuxt-link to="/" exact>
+							Home
+						</nuxt-link>
+					</li>
+
+					<li>
+						<nuxt-link to="/about/" exact>
+							About
+						</nuxt-link>
+					</li>
+
+					<li>
+						<!-- TODO: Remove style attribute. -->
+						<nuxt-link to="/tools/" style="display: none;" exact>
+							Tools
+						</nuxt-link>
+					</li>
+
+					<li>
+						<nuxt-link to="/inclusion-challenges/" exact>
+							Inclusion Challenges
+						</nuxt-link>
+					</li>
+
+					<li>
+						<!-- TODO: Remove style attribute. -->
+						<nuxt-link to="/our-data/" style="display: none;" exact>
+							Our Data
+						</nuxt-link>
+					</li>
+
+					<li>
+						<nuxt-link to="/news/" exact>
+							News
+						</nuxt-link>
+					</li>
+
+					<li>
+						<nuxt-link to="/views/" exact>
+							Views
 						</nuxt-link>
 					</li>
 				</ul>
@@ -27,21 +65,19 @@
 </template>
 
 <script>
-import Utils from "~/shared/Utils";
 import ContactInfo from "~/components/ContactInfo";
 import SocialMedia from "~/components/SocialMedia";
 import Funders from "~/components/Funders";
-
 export default {
 	components: {
 		ContactInfo,
 		SocialMedia,
 		Funders
 	},
-	computed: {
-		navMenu () {
-			return Utils.generateNavMenu(this.$store.state.sitePages, true);
-		}
+	data () {
+		return {
+			today: new Date()
+		};
 	}
 };
 </script>

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -6,7 +6,7 @@
 				<button id="menuToggleButton" @click="toggleNavMenu()" aria-expanded="false">
 					<MenuIcon />&nbsp;Menu
 				</button>
-				<NavBar :navMenu="navMenu" />
+				<NavBar />
 				<SearchForm />
 			</div>
 		</div>
@@ -14,7 +14,8 @@
 </template>
 
 <script>
-import Utils from "~/shared/Utils";
+// TODO
+// Want to make this more of a modal
 import Brand from "~/components/Brand";
 import NavBar from "~/components/NavBar";
 import SearchForm from "~/components/SearchForm";
@@ -27,10 +28,13 @@ export default {
 		SearchForm,
 		MenuIcon
 	},
-	computed: {
-		navMenu () {
-			return Utils.generateNavMenu(this.$store.state.sitePages);
-		}
+	data () {
+		return {
+			// Used on the mobile design to determine whether the navigation menu should be shown.
+			// Set to true when a user clicks on the "menu" icon to see the navigation menu.
+			// Set to false when a user clicks on the "menu" icon again to hide the navigation menu.
+			showMenu: false
+		};
 	},
 	mounted () {
 		// Attach the DOM listener that closes the navigation menu when the user clicks on anywhere

--- a/components/NavBar.vue
+++ b/components/NavBar.vue
@@ -1,18 +1,22 @@
 <template>
 	<nav class="nav-bar">
-		<nuxt-link v-for="menuItem in navMenu" :key="menuItem.slug" :to="menuItem.href">
-			{{ menuItem.title }}
+		<nuxt-link to="/about/">
+			About
+		</nuxt-link>
+		<nuxt-link to="/tools/" style="display: none;">
+			Tools
+		</nuxt-link>
+		<nuxt-link to="/inclusion-challenges/">
+			Inclusion Challenges
+		</nuxt-link>
+		<nuxt-link to="/our-data/" style="display: none;">
+			Our Data
+		</nuxt-link>
+		<nuxt-link to="/news/">
+			News
+		</nuxt-link>
+		<nuxt-link to="/views/">
+			Views
 		</nuxt-link>
 	</nav>
 </template>
-
-<script>
-export default {
-	props: {
-		navMenu: {
-			type: Array,
-			default: () => []
-		}
-	}
-};
-</script>

--- a/shared/DataFetcher.js
+++ b/shared/DataFetcher.js
@@ -58,9 +58,8 @@ export default {
 
 	async sitePages () {
 		// According to the Wordpress API for pagination and embedding: https://developer.wordpress.org/rest-api/using-the-rest-api/pagination/,
-		// 1. fetch 100 records per page (the maxium number per page supported by Wordpress) to fasten the query
-		// 2. Order by the menu order in ascending order
-		const pageAPI = Config.wpDomain + Config.apiBase + "pages?per_page=100&order=asc&orderby=menu_order";
+		// fetch 100 records per page (the maxium number per page supported by Wordpress) to fasten the query
+		const pageAPI = Config.wpDomain + Config.apiBase + "pages?per_page=100";
 
 		const response = await axios.get(`${pageAPI}`);
 
@@ -71,7 +70,6 @@ export default {
 				content: onePage.content.rendered,
 				// Strip html tags to get pure text for the content preview
 				excerpt: Utils.stripHtmlTags(onePage.content.rendered),
-				menu_order: onePage.menu_order,
 				href: "/" + onePage.slug + "/",
 				isExternalHref: false
 			};

--- a/shared/Utils.js
+++ b/shared/Utils.js
@@ -7,64 +7,6 @@ export default {
 	},
 
 	/**
-	 * generateNavMenu() returns an array of menu items. The structure of a menu item is:
-	 * @typedef {Object} MenuItem
-	 * @property {string} slug - The slug of the corresponding page that the menu item lands on.
-	 * @property {string} title - The title of the corresponding page that the menu item lands on.
-	 * @property {string} href - The href to direct the menu item to its corresponding page.
-	 */
-
-	/**
-	 * Generate the navigation menu based on the response from the Wordpress API.
-	 * The retun menu array will:
-	 * 1. Exclude all pages that have menu_order === 0;
-	 * 2. Append "News" and "Views" menu items to the end.
-	 * @param {array<Object>} sitePages - All menu pages sorted by menu_order.
-	 * @param {boolean} includeHomeItem - A flag indicating if the home menu item should be included.
-	 * @return {array<MenuItem>} An array of object including the slug, menu title and href.
-	 */
-	generateNavMenu (sitePages, includeHomeItem) {
-		const menuItems = [];
-		const homeMenuItem = [];
-		// Since "News" and "Views" don't have landing pages defined at the WP back-end, these menu items need to
-		// be explicitly appended to the nav menu. Using "append" is because they are the last 2 nav elements according
-		// to the design.
-		const extraMenuItemsToAppend = [{
-			slug: "news",
-			title: "News",
-			href: "/news"
-		}, {
-			slug: "views",
-			title: "Views",
-			href: "/views"
-		}];
-
-		sitePages.forEach((oneSitePage) => {
-			if (includeHomeItem && oneSitePage.slug === "home" && oneSitePage.menu_order === 0) {
-				// The title "Home" is hardcoded based on the slug is because the title received from the API response is
-				// `Creating an inclusive data ecosystem`, which doesn't provide any hint that it's a home page. And it also
-				// doesn't match what's on the design.
-				homeMenuItem.push({
-					slug: oneSitePage.slug,
-					title: "Home",
-					href: "/"
-				});
-			}
-
-			// Exclude pages that have menu_order === 0, which indicates the page should not be displayed on the header nav menu.
-			if (oneSitePage.menu_order !== 0) {
-				menuItems.push({
-					slug: oneSitePage.slug,
-					title: oneSitePage.title,
-					href: "/" + oneSitePage.slug
-				});
-			}
-		});
-
-		return [...homeMenuItem, ...menuItems, ...extraMenuItemsToAppend];
-	},
-
-	/**
 	 * @typedef {Object} Post
 	 * @property {string} slug - The slug of the post.
 	 * @property {string} title - The title of the post.

--- a/store/actions.js
+++ b/store/actions.js
@@ -23,9 +23,5 @@ export default {
 			const sitePages = await DataFetcher.sitePages();
 			context.commit("setSitePages", sitePages);
 		}
-	},
-
-	nuxtServerInit ({ dispatch }) {
-		return dispatch("fetchSitePages");
 	}
 };


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run dev` and reviewing affected routes
* [X] This pull request has been built by running `npm run generate` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

To resolve https://github.com/inclusive-design/wecount.inclusivedesign.ca/issues/208.

Revert the auto generation of the navigation menu.

## Steps to test

1. Start the site and verify the navigation menu.

**Expected behavior:**

The navigation menu should look