### PR TITLE
Style nav item

### DIFF
--- a/src/scss/layout/_header.scss
+++ b/src/scss/layout/_header.scss
@@ -128,7 +128,7 @@ header {
 
 					// When the user is in a section (other than the Home page), underline this particular item
 					// in the top level navigation.
-					a.nuxt-link-active {
+					a[aria-current="page"] {
 						border-bottom: rem(2) solid $white;
 					}
 				}


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [ ] This pull request has been tested by running `npm run dev` and reviewing affected routes
* [ ] This pull request has been built by running `npm run generate` without errors
* [x] This isn't a duplicate of an existing pull request

## Description
Use attribute selector to style the current link instead of `.nuxt-link-active`
<!-- Description of the pull request -->

## Steps to test

1. run `npm run build`
2. click around on link in the nav
3. the current link should have the following style: `border-bottom: rem(2) solid $white;`

**Expected behavior:** <!-- What should happen -->
The current link should have the following style: `border-bottom: rem(2) solid $white;`
## Additional information

<!-- Please provide any additional information that can help us review your contribution. -->

~~`npm run start` is not running due to:~~
```
sh: concurrently: command not found
```
~~`npm run build` is not running due to:~~
```
sh: cross-env: command not found
```
_UPDATE:_
After running `npm install` these commands are now working but stylesheets are not being applied in local development mode (after running `npm run start`).
## Related issues

<!-- If this pull request resolves an issue, please indicate the issue number here, e.g. 'Resolves #42' -->
resolves #213 