### PR TITLE
Re added h1 title to view side menu

### DIFF
--- a/src/transforms/parse.js
+++ b/src/transforms/parse.js
@@ -9,9 +9,8 @@ module.exports = function(value, outputPath) {
 		});
 
 		const document = DOM.window.document;
-		const articleTitle = document.querySelector("main article h1");
 		const articleHeadings = [
-			...document.querySelectorAll("main article.post h2, main article.post h3, main article.page h2, main article.page h3")
+			...document.querySelectorAll("main article.post-article h2, main article.page h2")
 		];
 
 		if (articleHeadings.length) {
@@ -23,7 +22,6 @@ module.exports = function(value, outputPath) {
 			tocLabel.className = "sr-only";
 			tocLabel.id = "toc-nav-label";
 
-			articleHeadings.unshift(articleTitle);
 			articleHeadings.forEach(heading => {
 				const headingSlug = slugify(heading.textContent.toLowerCase());
 

--- a/src/transforms/parse.js
+++ b/src/transforms/parse.js
@@ -9,6 +9,7 @@ module.exports = function(value, outputPath) {
 		});
 
 		const document = DOM.window.document;
+		const articleTitle = document.querySelector("main article h1");
 		const articleHeadings = [
 			...document.querySelectorAll("main article.post-article h2, main article.page h2")
 		];
@@ -22,6 +23,7 @@ module.exports = function(value, outputPath) {
 			tocLabel.className = "sr-only";
 			tocLabel.id = "toc-nav-label";
 
+			articleHeadings.unshift(articleTitle);
 			articleHeadings.forEach(heading => {
 				const headingSlug = slugify(heading.textContent.toLowerCase());
 


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run dev` and reviewing affected routes
* [x] This pull request has been built by running `npm run generate` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Readding  h1 title to view side menu

## Steps to test

1. run `npm run build`
2. Go to Views page
3. Click on the 3rd last or 4th last post (_Another test post_ or _Test views post_) or about or inclusive-challenges page
4. Make sure the side the title of the page is the first link in the side menu

**Expected behavior:** <!-- What should happen -->
This should jump to the section of the webpage where the title of the page is at the very top

## Additional information

<!-- Please provide any additional information that can help us review your contribution. -->
N/A
## Related issues

<!-- If this pull request resolves an issue, please indicate the issue number here, e.g. 'Resolves #42' -->

close #222 