### PR TITLE
feat: add pagination to the search page

### DIFF
--- a/src/_includes/components/pagination.njk
+++ b/src/_includes/components/pagination.njk
@@ -9,7 +9,6 @@
 
 <nav class="pagination" aria-label="pagination">
 	<ul class="pagination-list">
-		{# {{ pagination.pageNumber }} #}
 		<li>
 			{%- if pagination.href.previous %}
 			<a class="pagination-previous" href="{{ pagination.href.previous }}">

--- a/src/_includes/components/pagination.njk
+++ b/src/_includes/components/pagination.njk
@@ -1,12 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+		<symbol id="previous" width="14" height="24" viewBox="0 0 14 24">
+				{% include 'svg/prev.svg' %}
+		</symbol>
+		<symbol id="next" width="14" height="24" viewBox="0 0 14 24">
+				{% include 'svg/next.svg' %}
+		</symbol>
+</svg>
+
 <nav class="pagination" aria-label="pagination">
 	<ul class="pagination-list">
-		{%- if pagination.href.previous %}
+		{# {{ pagination.pageNumber }} #}
 		<li>
-			<a class="pagination-previous" href="{{ pagination.href.previous }}">{% include 'svg/prev.svg' %}<span class="screen-reader-only">previous</span></a>
+			{%- if pagination.href.previous %}
+			<a class="pagination-previous" href="{{ pagination.href.previous }}">
+				<svg><use xlink:href="#previous" /></svg>
+				<span class="screen-reader-only">previous</span>
+			</a>
+			{%- endif %}
 		</li>
-		{%- else %}
-		<li></li>{# TODO: Layout breaks without this empty element. #}
-		{%- endif %}
 		{%- if pagination.pageNumber > 1 %}
 		<li>
 			<a class="pagination-link" href="{{ pagination.href.first }}">1</a>
@@ -40,12 +51,13 @@
 			<a class="pagination-link" href="{{ pagination.href.last }}">{{ pagination.pages.length }}</a>
 		</li>
 		{%- endif %}
-		{%- if pagination.href.next %}
 		<li>
-			<a class="pagination-next" href="{{ pagination.href.next }}">{% include 'svg/next.svg' %}<span class="screen-reader-only">next</span></a>
+			{%- if pagination.href.next %}
+			<a class="pagination-next" href="{{ pagination.href.next }}">
+				<svg><use xlink:href="#next" /></svg>
+				<span class="screen-reader-only">next</span>
+			</a>
+			{%- endif %}
 		</li>
-		{%- else %}
-		<li></li>{# TODO: Layout breaks without this empty element. #}
-		{%- endif %}
 	</ul>
 </nav>

--- a/src/_includes/layouts/tag.njk
+++ b/src/_includes/layouts/tag.njk
@@ -2,7 +2,7 @@
 
 {% block content %}
     <article class="tags">
-        <h1>Tag: {{ tagItem.title }}</h1>
+        <h1>Tag: “{{ tagItem.title }}”</h1>
         <div class="news-grid">
 					{% for item in tagItem.posts %}
 					<div class="api-content">

--- a/src/_includes/svg/next.svg
+++ b/src/_includes/svg/next.svg
@@ -1,1 +1,1 @@
-<svg class="next" width="14" height="24" viewBox="0 0 14 24" xmlns="http://www.w3.org/2000/svg"><path d="M1 23L12 12L0.999999 0.999999" /></svg>
+<path d="M1 23L12 12L0.999999 0.999999" />

--- a/src/_includes/svg/prev.svg
+++ b/src/_includes/svg/prev.svg
@@ -1,1 +1,1 @@
-<svg class="previous" width="14" height="24" viewBox="0 0 14 24" xmlns="http://www.w3.org/2000/svg"><path d="M13 1L2 12L13 23" /></svg>
+<path d="M13 1L2 12L13 23" />

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -1,9 +1,11 @@
 // For search functionality on the header.
 
-/* global Vue, axios, htmlDecode, convertDate, stripHtmlTags */
+/* global Vue, axios, htmlDecode, convertDate, stripHtmlTags, createPagination */
 
 const params = new URLSearchParams(window.location.search);
 const searchQuery = params.get("s").toLowerCase();
+let pageInQuery = params.get("page");
+const pageSize = 10;
 
 new Vue({
 	el: "#defaultContainer",
@@ -12,6 +14,7 @@ new Vue({
 		axios.get(
 			window.location.origin + "/index.json"
 		).then(function (response) {
+			// Perform the search
 			const results = response.data.filter((oneRecord) => {
 				// Convert the fetched data to displayable values to work around the issue with using vue v-if and
 				// v-html in nunjucks templates.
@@ -22,14 +25,22 @@ new Vue({
 				const tagsInString = oneRecord.tags ? oneRecord.tags.join(" ") : "";
 				return oneRecord.title.concat(" ", oneRecord.content, " ", tagsInString).toLowerCase().match(searchQuery);
 			});
-			vm.searchResults = results;
+
+			// Paginate search results
+			let pagination;
+			if (results.length > pageSize) {
+				pagination = createPagination(results, pageSize, pageInQuery, "/search/?s=" + searchQuery + "&page=:page");
+			}
+			vm.pagination = pagination;
+			vm.resultsToDisplay = pagination ? pagination.items : results;
 			vm.searchStatus = `We found ${results.length} results for your search.`;
 		});
 	},
 	data: {
 		searchQuery: params.get("s"),
 		searchStatus: "Searching...",
-		searchResults: []
+		resultsToDisplay: [],
+		pagination: null
 	},
 	computed: {}
 });

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,5 +1,7 @@
 // Shared utility functions
 
+/* global chunkArray */
+
 // eslint-disable-next-line
 convertDate = function (inputDate) {
 	const dateObject = new Date(inputDate);
@@ -19,4 +21,43 @@ htmlDecode = function (input) {
 	let el = document.createElement("div");
 	el.innerHTML = input;
 	return el.innerText;
+};
+
+// eslint-disable-next-line
+chunkArray = function (inputArray, chunkSize) {
+	return Array(Math.ceil(inputArray.length / chunkSize)).fill().map((_, index) => index * chunkSize).map(begin => inputArray.slice(begin, begin + chunkSize));
+};
+
+// eslint-disable-next-line
+createPagination = function (dataArray, pageSize, pageInQuery, hrefTemplate) {
+	const dataInChunk = chunkArray(dataArray, pageSize);
+	pageInQuery = pageInQuery ? (parseInt(pageInQuery) > 1 ? parseInt(pageInQuery) : 1) : 1;
+	let hrefs = [];
+	for (let i = 0; i < dataInChunk.length; i++) {
+		hrefs.push(hrefTemplate.replace(":page", i + 1));
+	}
+
+	// The pagination data structure follows the Eleventy pagination data structure to make it easier to integrate
+	// pagination templates written in nunjucks and vue: https://www.11ty.dev/docs/pagination/#paging-an-array
+	const pagination = {
+		items: dataInChunk[pageInQuery - 1],
+		pageNumber: pageInQuery - 1,
+		hrefs: hrefs,
+		href: {
+			next: hrefs[pageInQuery] ? hrefs[pageInQuery] : null,
+			previous: hrefs[pageInQuery - 2] ? hrefs[pageInQuery - 2] : null,
+			first: hrefs[0],
+			last: hrefs[hrefs.length - 1]
+		},
+		pages: dataInChunk,
+		page: {
+			next: dataInChunk[pageInQuery] ? dataInChunk[pageInQuery] : null,
+			previous: dataInChunk[pageInQuery - 2] ? dataInChunk[pageInQuery - 2] : null,
+			first: dataInChunk[0],
+			last: dataInChunk[dataInChunk.length - 1]
+		},
+		hideProceedingPageButton: pageInQuery !== 2 && pageInQuery !== 3,
+		hideFollowingPageButton: pageInQuery !== dataInChunk.length - 1 && pageInQuery !== dataInChunk.length - 2
+	};
+	return pagination;
 };

--- a/src/scss/components/_pagination.scss
+++ b/src/scss/components/_pagination.scss
@@ -89,12 +89,25 @@
 	.pagination-next,
 	.pagination-previous {
 		color: $green-dark;
+		float: left;
+		line-height: rem(45);
+		margin: rem(10) rem(5);
 
 		svg {
 			fill: none;
+			height: rem(24);
 			stroke: currentColor;
 			stroke-width: 2;
+			width: rem(14);
 		}
+	}
+
+	.pagination-previous {
+		float: right;
+	}
+
+	.pagination-next {
+		float: left;
 	}
 
 	.pagination-next:hover,

--- a/src/search.njk
+++ b/src/search.njk
@@ -5,43 +5,104 @@ permalink: /search/
 {% extends 'layouts/base.njk' %}
 
 {% block content %}
-    <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
-        <symbol id="placeholder" viewBox="-4 -4 224 224">
-            {% include 'svg/placeholder.svg' %}
-        </symbol>
-    </svg>
+	<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+		<symbol id="placeholder" viewBox="-4 -4 224 224">
+			{% include 'svg/placeholder.svg' %}
+		</symbol>
+		<symbol id="previous" width="14" height="24" viewBox="0 0 14 24">
+			{% include 'svg/prev.svg' %}
+		</symbol>
+		<symbol id="next" width="14" height="24" viewBox="0 0 14 24">
+			{% include 'svg/next.svg' %}
+		</symbol>
+	</svg>
 
-    <article class="search">
-        <h1>Search results: {{ '{{ searchQuery }}' }}</h1>
-        <p role="status" v-if="searchStatus">{{ '{{ searchStatus }}' }}</p>
-        <div class="news-grid" v-if="searchResults.length > 0">
-          <div v-for="item in searchResults" :key="item.id" class="api-content">
-              <article class="news-item">
-                  <figure v-if="item.category==='views'" class="preview-media">
-                      <svg class="logo news-item-img">
-                          <use xlink:href="#placeholder" />
-                      </svg>
-                  </figure>
+	<article class="search">
+		<h1>Search results: "{{ '{{ searchQuery }}' }}"</h1>
+		<p role="status" v-if="searchStatus">{{ '{{ searchStatus }}' }}</p>
+		<div class="news-grid" v-if="resultsToDisplay.length > 0">
+		  <div v-for="item in resultsToDisplay" :key="item.id" class="api-content">
+			  {# TODO: The gride item layout below can go into a sharable vue template script
+			  when https://github.com/11ty/eleventy-plugin-vue is released #}
+			  <article class="news-item">
+				  <figure v-if="item.category==='views'" class="preview-media">
+					  <svg class="logo news-item-img">
+						  <use xlink:href="#placeholder" />
+					  </svg>
+				  </figure>
 
-                  <h2 class="h3">
-                      <a :href="item.href">
-                          {{ '{{ item.title }}' }}
-                      </a>
-                  </h2>
+				  <h2 class="h3">
+					  <a :href="item.href">
+						  {{ '{{ item.title }}' }}
+					  </a>
+				  </h2>
 
-                  <div v-if="item.category==='views'" class="author">
-                      {{ '{{ item.author }}' }}
-                  </div>
+				  <div v-if="item.category==='views'" class="author">
+					  {{ '{{ item.author }}' }}
+				  </div>
 
-                  <div v-if="item.dateTime" class="date">
-                      <time :datetime="item.dateTime" class="dt-published">{{ '{{ item.dateTime }}' }}</time>
-                  </div>
+				  <div v-if="item.dateTime" class="date">
+					  <time :datetime="item.dateTime" class="dt-published">{{ '{{ item.dateTime }}' }}</time>
+				  </div>
 
-                  <div v-html="item.excerpt" class="preview-content" />
-              </article>
-          </div>
-      </div>
-    </article>
+				  <div v-html="item.excerpt" class="preview-content" />
+			  </article>
+		  </div>
+	  </div>
+
+	  {# TODO: The pagination layout below can go into a sharable vue template script
+	  when https://github.com/11ty/eleventy-plugin-vue is released #}
+	  <nav v-if="pagination" class="pagination" aria-label="pagination">
+			<ul class="pagination-list">
+				<li>
+					<a v-if="pagination.href.previous" :href="pagination.href.previous" class="pagination-previous">
+						<svg><use xlink:href="#previous" /></svg>
+						<span class="screen-reader-only">previous</span>
+					</a>
+				</li>
+				<li v-if="pagination.pageNumber > 1">
+					<a :href="pagination.href.first" class="pagination-link d-1">1</a>
+				</li>
+				<li v-if="pagination.pageNumber > 2" class="pagination-ellipsis d-first-ellipsis">
+					<span>&hellip;</span>
+				</li>
+
+				<li v-if="pagination.pageNumber > 0" v-bind:class="{'hide-on-mobile': pagination.hideProceedingPageButton}">
+					<a :href="pagination.href.previous" class="pagination-link">
+						{{ '{{ pagination.pageNumber }}' }}
+					</a>
+				</li>
+
+				<li>
+					<a :href="pagination.hrefs[pagination.pageNumber]" class="pagination-link is-current" aria-current="page">
+						{{ '{{ pagination.pageNumber + 1 }}' }}
+					</a>
+				</li>
+
+				<li v-if="pagination.pageNumber < pagination.pages.length - 2" v-bind:class="{'hide-on-mobile': pagination.hideFollowingPageButton}">
+					<a :href="pagination.hrefs[pagination.pageNumber + 1]" class="pagination-link">
+						{{ '{{ pagination.pageNumber + 2 }}' }}
+					</a>
+				</li>
+
+				<li v-if="pagination.pageNumber < pagination.pages.length - 3" class="pagination-ellipsis d-last-ellipsis">
+					<span>&hellip;</span>
+				</li>
+				<li v-if="pagination.pageNumber < pagination.pages.length - 1">
+					<a :href="pagination.href.last" class="pagination-link">
+						{{ '{{ pagination.pages.length }}' }}
+					</a>
+				</li>
+				<li>
+					<a v-if="pagination.href.next" :href="pagination.href.next" class="pagination-next">
+						<svg><use xlink:href="#next" /></svg>
+						<span class="screen-reader-only">next</span>
+					</a>
+				</li>
+			</ul>
+		</nav>
+
+	</article>
 {% endblock %}
 
 {% block headerScripts %}

--- a/src/search.njk
+++ b/src/search.njk
@@ -18,7 +18,7 @@ permalink: /search/
 	</svg>
 
 	<article class="search">
-		<h1>Search results: "{{ '{{ searchQuery }}' }}"</h1>
+		<h1>Search results: “{{ '{{ searchQuery }}' }}”</h1>
 		<p role="status" v-if="searchStatus">{{ '{{ searchStatus }}' }}</p>
 		<div class="news-grid" v-if="resultsToDisplay.length > 0">
 		  <div v-for="item in resultsToDisplay" :key="item.id" class="api-content">
@@ -61,9 +61,9 @@ permalink: /search/
 					</a>
 				</li>
 				<li v-if="pagination.pageNumber > 1">
-					<a :href="pagination.href.first" class="pagination-link d-1">1</a>
+					<a :href="pagination.href.first" class="pagination-link">1</a>
 				</li>
-				<li v-if="pagination.pageNumber > 2" class="pagination-ellipsis d-first-ellipsis">
+				<li v-if="pagination.pageNumber > 2" class="pagination-ellipsis">
 					<span>&hellip;</span>
 				</li>
 
@@ -85,7 +85,7 @@ permalink: /search/
 					</a>
 				</li>
 
-				<li v-if="pagination.pageNumber < pagination.pages.length - 3" class="pagination-ellipsis d-last-ellipsis">
+				<li v-if="pagination.pageNumber < pagination.pages.length - 3" class="pagination-ellipsis">
 					<span>&hellip;</span>
 				</li>
 				<li v-if="pagination.pageNumber < pagination.pages.length - 1">


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Add the pagination to the search result page.

## Steps to test

1. Search by a keyword, for example, an empty space " ";
2. The search status text shows: Search results: " " (Note the double quotes around the empty character);
3. Only 10 results show up;
4. The pagination is shown underneath the result. Clicking through some of them to check if page url and content are directed correctly.
