### PR TITLE
fix: remove tabindex (resolves #257)

### DIFF
--- a/src/_includes/components/brand.njk
+++ b/src/_includes/components/brand.njk
@@ -1,5 +1,5 @@
 <div class="brand">
-    <a {% if page.url === '/' %}aria-current="page"{% endif %} rel="home" href="/" tabindex="1">
+    <a {% if page.url === '/' %}aria-current="page"{% endif %} rel="home" href="/">
         {% include 'svg/logo.svg' %}
         {% include 'svg/logotype.svg' %}
         <span class="screen-reader-only">We Count</span>


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Remove the `tabindex` attribute from the WeCount logo.

## Steps to test

1. Open any web page;
2. Using the "tab" key to move the mouse focus around the page.

**Expected behavior:** <!-- What should happen -->
The first focus should be on the "show preferences" button, then the WeCount logo.