### PR TITLE
fix: set the minimum value for UIO line space to 1 (resolves #253)

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -48,41 +48,6 @@
 			{% include 'components/footer.njk' %}
 		</div>
 		{% block footerScripts %}{% endblock %}
-		<script type="text/javascript">
-			$(document).ready(function () {
-				fluid.uiOptions(".flc-prefsEditor-separatedPanel", {
-					preferences: [
-						"fluid.prefs.lineSpace",
-						"fluid.prefs.textFont",
-						"fluid.prefs.contrast",
-						"fluid.prefs.tableOfContents",
-						"fluid.prefs.enhanceInputs",
-						"fluid.prefs.syllabification"
-					],
-					auxiliarySchema: {
-						terms: {
-							"templatePrefix": "/lib/infusion/src/framework/preferences/html",
-							"messagePrefix": "/lib/infusion/src/framework/preferences/messages"
-						},
-						"fluid.prefs.tableOfContents": {
-							enactor: {
-								"tocTemplate": "/lib/infusion/src/components/tableOfContents/html/TableOfContents.html",
-								"tocMessage": "/lib/infusion/src/framework/preferences/messages/tableOfContents-enactor.json"
-							}
-						},
-						"fluid.prefs.syllabification": {
-							enactor: {
-								terms: {
-									patternPrefix: "/lib/infusion/src/lib/hypher/patterns"
-								}
-							}
-						}
-					},
-					prefsEditorLoader: {
-						lazyLoad: true
-					}
-				});
-			});
-		</script>
+		<script src="/js/uio.js" defer></script>
 	</body>
 </html>

--- a/src/js/uio.js
+++ b/src/js/uio.js
@@ -1,0 +1,49 @@
+/* global $, fluid */
+
+$(document).ready(function () {
+	fluid.defaults("fluid.prefs.schemas.lineSpace", {
+		gradeNames: ["fluid.prefs.schemas"],
+		schema: {
+			"fluid.prefs.lineSpace": {
+				"type": "number",
+				"default": 1,
+				"minimum": 1,
+				"maximum": 2,
+				"multipleOf": 0.1
+			}
+		}
+	});
+
+	fluid.uiOptions(".flc-prefsEditor-separatedPanel", {
+		preferences: [
+			"fluid.prefs.lineSpace",
+			"fluid.prefs.textFont",
+			"fluid.prefs.contrast",
+			"fluid.prefs.tableOfContents",
+			"fluid.prefs.enhanceInputs",
+			"fluid.prefs.syllabification"
+		],
+		auxiliarySchema: {
+			terms: {
+				"templatePrefix": "/lib/infusion/src/framework/preferences/html",
+				"messagePrefix": "/lib/infusion/src/framework/preferences/messages"
+			},
+			"fluid.prefs.tableOfContents": {
+				enactor: {
+					"tocTemplate": "/lib/infusion/src/components/tableOfContents/html/TableOfContents.html",
+					"tocMessage": "/lib/infusion/src/framework/preferences/messages/tableOfContents-enactor.json"
+				}
+			},
+			"fluid.prefs.syllabification": {
+				enactor: {
+					terms: {
+						patternPrefix: "/lib/infusion/src/lib/hypher/patterns"
+					}
+				}
+			}
+		},
+		prefsEditorLoader: {
+			lazyLoad: true
+		}
+	});
+});

--- a/src/js/uio.js
+++ b/src/js/uio.js
@@ -1,19 +1,6 @@
 /* global $, fluid */
 
 $(document).ready(function () {
-	fluid.defaults("fluid.prefs.schemas.lineSpace", {
-		gradeNames: ["fluid.prefs.schemas"],
-		schema: {
-			"fluid.prefs.lineSpace": {
-				"type": "number",
-				"default": 1,
-				"minimum": 1,
-				"maximum": 2,
-				"multipleOf": 0.1
-			}
-		}
-	});
-
 	fluid.uiOptions(".flc-prefsEditor-separatedPanel", {
 		preferences: [
 			"fluid.prefs.lineSpace",
@@ -44,6 +31,13 @@ $(document).ready(function () {
 		},
 		prefsEditorLoader: {
 			lazyLoad: true
+		},
+		schema: {
+			properties: {
+				"fluid.prefs.lineSpace": {
+					"minimum": 1
+				}
+			}
 		}
 	});
 });

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -5,6 +5,7 @@ mix.setPublicPath("./src/_includes/static/");
 mix.sass("./src/scss/main.scss", "./src/_includes/static/css/main.css");
 
 mix.js("./src/js/main.js", "./src/_includes/static/js/main.js");
+mix.js("./src/js/uio.js", "./src/_includes/static/js/uio.js");
 mix.js("./src/js/utils.js", "./src/_includes/static/js/utils.js");
 mix.js("./src/js/search.js", "./src/_includes/static/js/search.js");
 


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

To resolve #253.

Set the minimum value for the UIO line space to 1.

## Steps to test

1. Go to any webpage and open UIO;
2. The value in the UIO line space input field is 1;
3. Cannot use "-" button to the left of the input field to decrease the value;
4. Select a high or low contrast theme;
5. Go to the "news" page

**Expected behavior:** <!-- What should happen -->

News titles are shown properly without any cut-off on texts.