### PR TITLE
fix: remove line-height definitions from footer elements (resolves #254)

### DIFF
--- a/src/scss/layout/_footer.scss
+++ b/src/scss/layout/_footer.scss
@@ -32,7 +32,6 @@ footer {
 		display: flex;
 		flex-direction: column;
 		font-size: rem(16);
-		line-height: rem(29);
 		margin: auto;
 		max-width: $max-width-margins;
 
@@ -216,7 +215,6 @@ footer {
 				align-self: end;
 				grid-column: 2/3;
 				grid-row: 2/3;
-				line-height: rem(19);
 			}
 
 			.contact-info {


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

To resolve #254.

Footer texts respond to the change of UIO line space value.

## Steps to test

1. Open any webpage;
2. Scroll to the footer;
3. Footer texts look good;
4. Open UIO and increase the line space value;
5. Scroll to the footer to check the line space of footer texts.

**Expected behavior:** <!-- What should happen -->

The line space of footer texts increase and respond to the change of the line space value.
