### PR TITLE
fix: the change of UIO line space value no longer affects the pagination (resolves #255)

### DIFF
--- a/src/scss/components/_pagination.scss
+++ b/src/scss/components/_pagination.scss
@@ -1,5 +1,6 @@
 .pagination {
 	display: block;
+	line-height: rem(32);
 	list-style: none;
 	margin-top: rem(62);
 	padding: 0;


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

To resolve #255.

The change of UIO line space value no longer affects the position of ellipses on the pagination.

## Steps to test

1. Go to the "views" page;
2. Open UIO and increase the line space value;
3. Scroll to the pagination area.

**Expected behavior:** <!-- What should happen -->

The position of ellipses on the pagination doesn't shift and remain at the same position as when the line space value is 1.