### PR TITLE
fix: svgs now respond to theme colors when the enhance inputs is on (resolves #266)

### DIFF
--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -1,5 +1,29 @@
 // Mixins.
 @mixin adapt-to-highContrast($fColor, $bColor) {
+	// WeCount logo
+	.logo circle,
+	.logo path {
+		fill: none;
+		stroke: var(--logo-stroke, currentColor);
+		stroke-linecap: round;
+		stroke-width: rem(3);
+	}
+
+	// Search icon; IDRC, OCADU and Canada logos
+	header .site-nav-wrapper .site-nav .search-container svg {
+		fill: currentColor;
+	}
+
+	// Canada logo
+	--theme-link-fill: currentColor;
+
+	// Placeholder images on the "views" page
+	svg.news-item-img use {
+		stroke: var(--placeholder-stroke, currentColor);
+		stroke-linecap: round;
+		stroke-width: rem(3);
+	}
+
 	// Social media icons
 	footer .footer-content .social-media .social-media-icons a {
 		svg path {

--- a/src/scss/vendors/_vendors.scss
+++ b/src/scss/vendors/_vendors.scss
@@ -89,34 +89,6 @@
 	}
 }
 
-// To adapt to UIO high contrast themes
-[class^="gpii-ext-theme"],
-[class^="fl-theme"]:not(.fl-theme-prefsEditor-default) {
-	// WeCount logo
-	.logo circle,
-	.logo path {
-		fill: none;
-		stroke: var(--logo-stroke, currentColor);
-		stroke-linecap: round;
-		stroke-width: rem(3);
-	}
-
-	// Search icon; IDRC, OCADU and Canada logos
-	header .site-nav-wrapper .site-nav .search-container svg {
-		fill: currentColor;
-	}
-
-	// Canada logo
-	--theme-link-fill: currentColor;
-
-	// Placeholder images on the "views" page
-	svg.news-item-img use {
-		stroke: var(--placeholder-stroke, currentColor);
-		stroke-linecap: round;
-		stroke-width: rem(3);
-	}
-}
-
 // For styles that require foreground and background colors from each theme
 @each $theme, $fColor, $bColor in $UIOThemes {
 	.fl-theme-#{$theme}, .gpii-ext-theme-#{$theme} {


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

To resolve #266.

SVGs now respond to theme colors correctly when the enhance inputs is on. This issue is fixed by attaching css with each theme selector rather than a generic selector with a low specificity.

## Steps to test

1. Open UIO and turn on "enhance inputs";
2. Select a contrast theme;
3. Check logo, svgs on the header and footer, placeholder svgs on the "views" page;
4. The color of all of them should respond to the selected theme;
5. Select a few other themes and check SVGs again.

**Expected behavior:** <!-- What should happen -->

The color of SVGs should respond to the selected theme regardless the "enhance inputs" is turned on or not.