### PR TITLE
fix: display the footer in the desktop layout from the ipad size screen

### DIFF
--- a/src/scss/layout/_footer.scss
+++ b/src/scss/layout/_footer.scss
@@ -158,7 +158,7 @@ footer {
 	}
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: 768px) {
 	footer {
 		margin-top: rem(0);
 
@@ -215,6 +215,10 @@ footer {
 				align-self: end;
 				grid-column: 2/3;
 				grid-row: 2/3;
+
+				svg {
+					margin-bottom: rem(16);
+				}
 			}
 
 			.contact-info {


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Display the footer in the desktop layout starting from the ipad size screens.

## Steps to test

1. Open any web page;
2. Switch to the responsive design mode and pick "ipad";
3. Scroll to the footer. The footer should be displayed in the desktop layout;
4. Pick a screen that is smaller than the ipad. The footer should be displayed in the mobile layout;
5. Pick a screen that is larger than the ipad. The footer should be displayed in the desktop layout.

**Expected behavior:** <!-- What should happen -->

See above.