### PR TITLE
fix: Implement the style for UIO table of content (resolves #232)

### DIFF
--- a/src/js/uio.js
+++ b/src/js/uio.js
@@ -18,7 +18,11 @@ $(document).ready(function () {
 			"fluid.prefs.tableOfContents": {
 				enactor: {
 					"tocTemplate": "/lib/infusion/src/components/tableOfContents/html/TableOfContents.html",
-					"tocMessage": "/lib/infusion/src/framework/preferences/messages/tableOfContents-enactor.json"
+					"tocMessage": "/lib/infusion/src/framework/preferences/messages/tableOfContents-enactor.json",
+					ignoreForToC: {
+						"footer": "footer",
+						"tags": ".tags-info"
+					}
 				}
 			},
 			"fluid.prefs.syllabification": {

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -117,7 +117,7 @@
 		background: $bColor;
 	}
 
-	@media screen and (min-width: 1024px) {
+	@media screen and (min-width: rem(1024)) {
 		// Adjust the position of the search icon on the header
 		header .site-nav-wrapper .site-nav .search-container svg {
 			height: rem(24);

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -117,6 +117,11 @@
 		background: $bColor;
 	}
 
+	// UIO table of content
+	.flc-toc-tocContainer ul li::before {
+		color: $fColor;
+	}
+
 	@media screen and (min-width: rem(1024)) {
 		// Adjust the position of the search icon on the header
 		header .site-nav-wrapper .site-nav .search-container svg {

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -91,7 +91,7 @@ button::before:not(.fl-prefsEditor-buttons button) {
 	width: 100%;
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: rem(1024)) {
 	h1 {
 		font-size: rem(64);
 	}

--- a/src/scss/components/_aside.scss
+++ b/src/scss/components/_aside.scss
@@ -3,7 +3,7 @@ aside {
 	justify-self: end;
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: rem(1024)) {
 	aside {
 		display: inherit;
 		padding-top: rem(58);

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -48,7 +48,7 @@
 	}
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: rem(1024)) {
 	.homepage-cards {
 		background-color: $white;
 		grid-gap: rem(38);

--- a/src/scss/components/_news-and-views.scss
+++ b/src/scss/components/_news-and-views.scss
@@ -201,7 +201,7 @@
 	}
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: rem(1024)) {
 	.news-grid {
 		grid-template-columns: repeat(2, 1fr);
 

--- a/src/scss/components/_pagination.scss
+++ b/src/scss/components/_pagination.scss
@@ -124,7 +124,7 @@
 	}
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: rem(1024)) {
 	.pagination {
 		.previous,
 		.next {

--- a/src/scss/layout/_footer.scss
+++ b/src/scss/layout/_footer.scss
@@ -158,7 +158,7 @@ footer {
 	}
 }
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: rem(768)) {
 	footer {
 		margin-top: rem(0);
 

--- a/src/scss/layout/_header.scss
+++ b/src/scss/layout/_header.scss
@@ -107,7 +107,7 @@ header {
 	}
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: rem(1024)) {
 	header {
 		.site-nav-wrapper {
 			.site-nav {

--- a/src/scss/layout/_layout.scss
+++ b/src/scss/layout/_layout.scss
@@ -100,10 +100,10 @@ figcaption {
 	}
 
 	main {
+		background-color: $white;
 		max-width: 130ch;
 
 		article {
-			background-color: $white;
 			padding: rem(1) rem(60);
 			padding-bottom: rem(62);
 

--- a/src/scss/vendors/_vendors.scss
+++ b/src/scss/vendors/_vendors.scss
@@ -2,7 +2,7 @@
 
 // *** UIO ***
 
-// UIO button style
+// UIO button style by default
 #defaultContainer .fl-prefsEditor-separatedPanel .fl-panelBar {
 	border-bottom: none;
 	box-shadow: none;
@@ -32,7 +32,7 @@
 	}
 }
 
-// Stlying for when enhance inputs is turned on
+// UIO button style when enhance inputs is turned on
 .fl-input-enhanced #defaultContainer .fl-prefsEditor-separatedPanel .fl-panelBar .fl-prefsEditor-buttons {
 	display: inline-block;
 	height: rem(88);
@@ -60,6 +60,33 @@
 		padding-bottom: rem(15);
 		padding-left: rem(10);
 		width: 97%;
+	}
+}
+
+// UIO table of content
+.flc-toc-tocContainer {
+	font-size: rem(18);
+	font-weight: $font-weight-semibold;
+	padding: rem(0) rem(27);
+
+	.flc-toc-header {
+		margin-bottom: rem(16);
+	}
+
+	// h1 list style: filled circle
+	ul {
+		list-style: initial;
+		margin-left: rem(16);
+	}
+
+	// h2 list style: empty circle
+	ul ul {
+		list-style: circle;
+	}
+
+	// h3 list style: filled square
+	ul ul ul {
+		list-style: square;
 	}
 }
 
@@ -96,5 +123,12 @@
 			margin-top: 0;
 			padding: 0 rem(3);
 		}
+	}
+}
+
+@media screen and (min-width: rem(1024)) {
+	// UIO table of content
+	.flc-toc-tocContainer {
+		padding: rem(1) rem(60);
 	}
 }

--- a/src/scss/vendors/_vendors.scss
+++ b/src/scss/vendors/_vendors.scss
@@ -65,8 +65,6 @@
 
 // UIO table of content
 .flc-toc-tocContainer {
-	font-size: rem(18);
-	font-weight: $font-weight-semibold;
 	padding: rem(0) rem(27);
 
 	.flc-toc-header {
@@ -75,13 +73,27 @@
 
 	// The list style for h1: solid circle
 	ul {
-		list-style: initial;
+		list-style: none;
 		margin-left: rem(16);
+
+		a {
+			color: $navy-light;
+			font-size: rem(18);
+			font-weight: $font-weight-semibold;
+		}
+	}
+
+	ul li::before {
+		color: $navy-light;
+		content: "\25CF";
+		display: inline-block;
+		margin-left: rem(-16);
+		width: rem(12);
 	}
 
 	// The list style for h2 and other heading levels: empty circle
-	ul ul {
-		list-style: circle;
+	ul ul li::before {
+		content: "\25CB";
 	}
 }
 

--- a/src/scss/vendors/_vendors.scss
+++ b/src/scss/vendors/_vendors.scss
@@ -73,20 +73,15 @@
 		margin-bottom: rem(16);
 	}
 
-	// h1 list style: filled circle
+	// The list style for h1: solid circle
 	ul {
 		list-style: initial;
 		margin-left: rem(16);
 	}
 
-	// h2 list style: empty circle
+	// The list style for h2 and other heading levels: empty circle
 	ul ul {
 		list-style: circle;
-	}
-
-	// h3 list style: filled square
-	ul ul ul {
-		list-style: square;
 	}
 }
 

--- a/src/scss/vendors/_vendors.scss
+++ b/src/scss/vendors/_vendors.scss
@@ -87,8 +87,9 @@
 		color: $navy-light;
 		content: "\25CF";
 		display: inline-block;
+		font-size: 120%;
 		margin-left: rem(-16);
-		width: rem(12);
+		width: rem(10);
 	}
 
 	// The list style for h2 and other heading levels: empty circle


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Implement the style for UIO table of content according to [the design](https://www.figma.com/file/0lcLol3X5MmOXackT2YbHJ/WeCount-website).

## Steps to test

1. Go to the deploy preview and turn on UIO "table of content";
2. Go through different type of pages to make sure the implementation matches the design;

**Expected behavior:** <!-- What should happen -->

A few clarification on top of the design:
1. The list style for h1 is solid circles, for other heading levels are empty circles;
2. The table of content for "news" page also list all post titles;
3. These items should be excluded from the table of content:
* All headings on the footer
* The "Tags" heading on the views post pages
