### PR TITLE
fix: update facebook URL for WeCount project (resolves #275)

### DIFF
--- a/src/_data/social.json
+++ b/src/_data/social.json
@@ -1,5 +1,5 @@
 {
-    "facebook": "https://www.facebook.com/wecountproject/",
+    "facebook": "https://www.facebook.com/We-Count-Project-103084404745143/",
     "instagram": "https://www.instagram.com/wecount_project/",
     "twitter": "https://twitter.com/WeCountproject"
 }


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Fix the broken facebook link.

## Steps to test

1. Open any page;
2. Scroll to the bottom and click on the facebook link.

**Expected behavior:** <!-- What should happen -->

The link should take the page to [the WeCount project facebook page](https://www.facebook.com/We-Count-Project-103084404745143/).