### PR TITLE
fix: non-views posts on search results don't keep preview image blocks

### DIFF
--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -19,6 +19,10 @@
 		right: 0;
 		top: 0;
 	}
+
+	&:empty::before {
+		padding-top: 0;
+	}
 }
 
 // To adapt to UIO contrast themes


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Non-views posts on search results don't keep preview image blocks

## Steps to test

1. Search for the keyword "ai";
2. Non-views posts on the search result should not keep space for preview images.

**Expected behavior:** <!-- What should happen -->

See above.