### PR TITLE
fix: the search container doesn't overlap with the view item on desktop (resolves #288)

### DIFF
--- a/src/scss/layout/_header.scss
+++ b/src/scss/layout/_header.scss
@@ -7,7 +7,6 @@ header {
 	.search-container {
 		align-items: center;
 		display: flex;
-		margin-left: rem(40);
 
 		svg {
 			fill: white;
@@ -118,6 +117,8 @@ header {
 @media screen and (min-width: rem(1024)) {
 	header {
 		.search-container {
+			margin-left: rem(80);
+
 			svg {
 				margin: rem(-40);
 			}


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

The left border of the search container no longer overlaps with the menu bar on the desktop view when a UIO theme is selected.

## Steps to test

1. Open UIO and select a theme. Make sure the browser is on the desktop view;
2. The left border of the search container no longer overlaps with the menu bar;
3. Switch to the mobile view;
4. The search should look and work properly.

**Expected behavior:** <!-- What should happen -->

See above.