### PR TITLE
fix: placeholder preview images should show when a UIO theme is selected (resolves #291)

### DIFF
--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -50,7 +50,7 @@
 	--theme-link-fill: currentColor;
 
 	// Placeholder images on the "views" page
-	svg.news-item-img use {
+	svg.placeholder-img use {
 		stroke: var(--placeholder-stroke, currentColor);
 		stroke-linecap: round;
 		stroke-width: rem(3);


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Placeholder preview images should show when a UIO theme is selected

## Steps to test

1. Open UIO and select a theme;
2. Go to the "Views" page, select page 11;

**Expected behavior:** <!-- What should happen -->

Placeholder preview images should adjust colors to the selected theme.
