### PR TITLE
fix: change the url of the LinkedIn icon (resolves #294)

### DIFF
--- a/src/_data/social.json
+++ b/src/_data/social.json
@@ -2,5 +2,5 @@
     "facebook": "https://www.facebook.com/We-Count-Project-103084404745143/",
     "instagram": "https://www.instagram.com/wecount_project/",
     "twitter": "https://twitter.com/WeCountproject",
-    "linkedin": "https://www.linkedin.com/in/wecountproject/"
+    "linkedin": "https://www.linkedin.com/company/we-count/"
 }


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

To change the url of the LinkedIn icon to https://www.linkedin.com/company/we-count/

## Steps to test

1. Scroll to the footer;
2. Click the LinkedIn icon in the "social media" section.

**Expected behavior:** <!-- What should happen -->

The page should be taken to this URL: https://www.linkedin.com/company/we-count/