### PR TITLE
fix: fix html validation errors and warnings (resolves #302)

### DIFF
--- a/src/_includes/components/nav-menu.njk
+++ b/src/_includes/components/nav-menu.njk
@@ -1,5 +1,4 @@
-<nav class="primary-nav" aria-labelledby="primary-nav-label">
-  <span id="primary-nav-label" class="screen-reader-only">Primary Navigation</span>
+<nav class="primary-nav" aria-label="Primary Navigation">
   {%- for pageItem in collections.pages %}
     {%- if pageItem.menu_order > 0 %}
     <a {% if page.url === '/' + pageItem.slug + '/' %}aria-current="page" {% endif %}href="/{{ pageItem.slug }}/">{{ pageItem.title }}</a>

--- a/src/_includes/components/search-container.njk
+++ b/src/_includes/components/search-container.njk
@@ -1,6 +1,6 @@
 <div class="search-container">
 	{% include 'svg/search.svg' %}
-	<form id="search-form" method="get" action="/search/">
+	<form method="get" action="/search/">
 		<input name="s" type="search" placeholder="Search..." aria-label="Enter keywords for a site-wide search">
 	</form>
 </div>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -23,5 +23,5 @@ document.addEventListener("click", (event) => {
 // Clicking the search svg on the header enlarges the search input box and places the focus in it.
 // This is required for the mobile layout where the search icon overlays on top of the input field.
 document.querySelector(".site-nav .nav-smallScreen .search-container svg").addEventListener("click", () => {
-	document.querySelector(".site-nav .nav-smallScreen .search-container #search-form input").focus();
+	document.querySelector(".site-nav .nav-smallScreen .search-container input").focus();
 });

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -91,7 +91,7 @@
 	#defaultContainer header .site-nav-wrapper .site-nav nav a:hover,
 	#defaultContainer .content-wrapper .tags-info .tags a:focus,
 	#defaultContainer .content-wrapper .tags-info .tags a:hover,
-	#search-form input,
+	.search-container input,
 	.card:focus,
 	.card:hover,
 	button:focus,


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Fix html validation errors and warnings.

## Steps to test

1. Go to [W3C html validator](https://validator.w3.org/);
2. In "Validate by URI" tab, enter "https://dev--wecount.netlify.app/" and click the "check" button;
3. There shouldn't be any errors or warnings;
4. Try other WeCount URLs and make sure no validation errors and warnings;
5. Test the search container in the header to make sure: 
* It works properly with the search on desktop and mobile layouts
* It responds to UIO theme change

**Expected behavior:** <!-- What should happen -->

See above
