### PR TITLE
fix: news and views should be sorted by date published, not modified

### DIFF
--- a/src/utils/data-fetcher.js
+++ b/src/utils/data-fetcher.js
@@ -27,8 +27,8 @@ module.exports = {
 		// According to the Wordpress API for pagination and embedding: https://developer.wordpress.org/rest-api/using-the-rest-api/pagination/
 		// 1. Fetch 100 records per page (the maxium number per page supported by Wordpress) to fasten the query
 		// 2. Retrieve embedded resources in the main query
-		// 3. Order by the modified date in descending order
-		const baseCategoryAPI = env.api + "/posts?categories=" + categoryId + "&per_page=100&orderby=modified&order=desc&_embed";
+		// 3. Order by the published date in descending order
+		const baseCategoryAPI = env.api + "/posts?categories=" + categoryId + "&per_page=100&orderby=date&order=desc&_embed";
 
 		// Fetch records for the first page as well as the number of total pages
 		const firstPageRequest = baseCategoryAPI + "&page=1";


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

I noticed that on the Views page, the posts were not in the correct reverse chronological order: https://wecount.inclusivedesign.ca/views/

This appears to have been a bug in the data fetcher utility. When it was created it was set up to fetch items in reverse chronological order based on date modified. However, this means that if a post is edited it will be moved to the start of the list— so adding featured images to old Views posts had reordered them.

This PR addresses the issue by changing the `orderby` parameter to `date` (date created) instead of `modified`.

## Steps to test

1. Check out this branch.
2. Run `npm run start`.
3. Visit News and Views pages.

**Expected behavior:** Content is shown in reverse chronological order based on publication date.

## Additional information

Not applicable.

## Related issues

Not applicable.
