### PR TITLE
fix: heading elements should be in a sequentially-descending order (resolves #309)

### DIFF
--- a/src/page.njk
+++ b/src/page.njk
@@ -22,13 +22,13 @@ permalink: "/{{ '/' if pageItem.slug === 'home' else pageItem.slug  }}/"
     </article>
     <div class="homepage-cards">
 			<a href="/views/" class="blue card">
-				<h3>Read current views in inclusive data science</h3>
+				<h2 class="h3">Read current views in inclusive data science</h2>
 			</a>
 			<a href="/tools/" class="green card" hidden>
-				<h3>Find inclusive data tools</h3>
+				<h2 class="h3">Find inclusive data tools</h2>
 			</a>
 			<a href="/inclusion-challenges/" class="yellow card">
-				<h3>Participate in our inclusion challenge workshops</h3>
+				<h2 class="h3">Participate in our inclusion challenge workshops</h2>
 			</a>
 		</div>
 </div>

--- a/src/post.njk
+++ b/src/post.njk
@@ -26,7 +26,7 @@ permalink: "views/{{ postItem.slug }}/"
   <div class="api-content">{{ postItem.content | safe }}</div>
 	{% if postItem.tags.length > 0 %}
   <section class="tags-info">
-    <h3>Tags</h3>
+    <h2 class="h3">Tags</h2>
     <div class="tags">
     {% for tag in postItem.tags %}
     <a href="/tags/{{ tag | slug }}/">{{ tag | safe }}</a>

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -35,7 +35,7 @@
 	a {
 		height: rem(213);
 
-		h3 {
+		h2 {
 			color: $navy-light;
 			font-weight: $font-weight-medium;
 			line-height: rem(35);

--- a/src/scss/components/_post-article.scss
+++ b/src/scss/components/_post-article.scss
@@ -27,7 +27,7 @@
 	}
 
 	.tags-info {
-		h3 {
+		h2 {
 			color: $green-dark;
 			margin: rem(8) 0;
 		}


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Heading elements on a page should be in a sequentially-descending order.

## Steps to test

1. Go to "Home" page;
2. Open the page source, heading levels on the page should be h1 -> h2;
3. Go to a post page and check the page source, heading levels should be h1 -> h2.

**Expected behavior:** <!-- What should happen -->

See above.
