### PR TITLE
fix: added styling to download buttons (resolves #314)

### DIFF
--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -93,6 +93,10 @@
 		}
 	}
 
+	// Focus/hover styles for buttons
+	.wp-block-file__button {
+		box-shadow: 0 0 0 rem(1) currentColor inset;
+	}
 	// Focus/hover styles for links
 	#defaultContainer a:focus,
 	#defaultContainer a:hover,
@@ -103,6 +107,8 @@
 	.search-container input,
 	.card:focus,
 	.card:hover,
+	.wp-block-file__button:focus,
+	.wp-block-file__button:hover,
 	button:focus,
 	button:hover,
 	li .pagination-link,

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -93,10 +93,11 @@
 		}
 	}
 
-	// Focus/hover styles for buttons
+	// Styles for buttons
 	.wp-block-file__button {
 		box-shadow: 0 0 0 rem(1) currentColor inset;
 	}
+
 	// Focus/hover styles for links
 	#defaultContainer a:focus,
 	#defaultContainer a:hover,
@@ -107,12 +108,12 @@
 	.search-container input,
 	.card:focus,
 	.card:hover,
-	.wp-block-file__button:focus,
-	.wp-block-file__button:hover,
 	button:focus,
 	button:hover,
 	li .pagination-link,
-	li .pagination-link::before {
+	li .pagination-link::before,
+	.wp-block-file__button:focus,
+	.wp-block-file__button:hover {
 		box-shadow: 0 0 0 rem(2) currentColor inset;
 	}
 

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -107,11 +107,8 @@ button::before:not(.fl-prefsEditor-buttons) button {
 	.wp-block-file__button {
 		display: block;
 		font-size: rem(14);
+		font-weight: $font-weight-medium;
 		height: auto;
-		margin: auto;
-		margin-top: rem(8);
-		position: relative;
-		top: rem(-3);
 	}
 }
 
@@ -121,12 +118,10 @@ button::before:not(.fl-prefsEditor-buttons) button {
 	}
 
 	.wp-block-file {
-		margin-bottom: rem(20);
 		text-align: unset;
 
 		.wp-block-file__button {
 			display: inline;
-			margin-left: rem(50);
 		}
 	}
 }

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -45,6 +45,9 @@ a:focus {
 	outline: none;
 }
 
+.wp-block-file__button:hover::before,
+.wp-block-file__button:focus::before,
+.wp-block-file__button:active::before,
 button:hover::before,
 button:focus::before,
 button:active::before {
@@ -52,19 +55,24 @@ button:active::before {
 	top: rem(4);
 }
 
+.wp-block-file__button::-moz-focus-inner,
 button::-moz-focus-inner {
 	outline: none;
 }
 
+.wp-block-file__button:focus,
 button:focus {
 	outline: none;
 }
 
+.wp-block-file__button:-moz-focusring,
 button:-moz-focusring {
 	color: transparent;
 	text-shadow: 0 0 0 $green-dark;
 }
 
+// stylelint-disable-next-line
+.wp-block-file__button,
 button:not(.fl-prefsEditor-buttons) button {
 	background-color: $green-light;
 	border: 0;
@@ -79,6 +87,8 @@ button:not(.fl-prefsEditor-buttons) button {
 	transform: perspective(rem(1)) translateZ(0);
 }
 
+// stylelint-disable-next-line
+.wp-block-file__button,
 button::before:not(.fl-prefsEditor-buttons) button {
 	border-radius: rem(26);
 	box-shadow: 0 0 0 rem(2) $blue-alt-light inset;
@@ -91,8 +101,32 @@ button::before:not(.fl-prefsEditor-buttons) button {
 	width: 100%;
 }
 
+.wp-block-file {
+	text-align: center;
+
+	.wp-block-file__button {
+		display: block;
+		font-size: rem(14);
+		height: auto;
+		margin: auto;
+		margin-top: rem(8);
+		position: relative;
+		top: rem(-3);
+	}
+}
+
 @media screen and (min-width: rem(1024)) {
 	h1 {
 		font-size: rem(64);
+	}
+
+	.wp-block-file {
+		margin-bottom: rem(20);
+		text-align: unset;
+
+		.wp-block-file__button {
+			display: inline;
+			margin-left: rem(50);
+		}
 	}
 }


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Added proper styling to download buttons.

## Steps to test

1. Go to the deploy preview.
2. Go to the Views page then select the "Journeys through the Digital Innovation Appendix of the Master Innovation and Development Plan" post.
3. Observe the styling of the download button.

**Expected behavior:** <!-- What should happen -->

The download button should have the same style as all other buttons as specified in [Figma](https://www.figma.com/file/0lcLol3X5MmOXackT2YbHJ/WeCount-website?node-id=1622%3A5648)
## Additional information

Issues with figures will be resolved in #137 
<!-- Please provide any additional information that can help us review your contribution. -->

## Related issues
resolves #314 
<!-- If this pull request resolves an issue, please indicate the issue number here, e.g. 'Resolves #42' -->
