### PR TITLE
fix: adjust box shadows for the card links on the home page (resolves #319)

### DIFF
--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -111,8 +111,6 @@
 	#defaultContainer .content-wrapper .tags-info .tags a:focus,
 	#defaultContainer .content-wrapper .tags-info .tags a:hover,
 	.search-container input,
-	.card:focus,
-	.card:hover,
 	button:focus,
 	button:hover,
 	li .pagination-link,
@@ -154,6 +152,11 @@
 		.card {
 			background-image: none;
 			box-shadow: 0 rem(4) rem(4) currentColor;
+
+			&:focus,
+			&:hover {
+				box-shadow: 0 0 0 rem(2) currentColor inset;
+			}
 		}
 	}
 

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -150,11 +150,10 @@
 			}
 		}
 
-		// Home page cards: hide background images on UIO contrast themes
-		.blue,
-		.green,
-		.yellow {
+		// Home page cards: hide background images and adjust box shadows on UIO contrast themes
+		.card {
 			background-image: none;
+			box-shadow: 0 rem(4) rem(4) currentColor;
 		}
 	}
 

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -155,7 +155,7 @@
 
 			&:focus,
 			&:hover {
-				box-shadow: 0 0 0 rem(2) currentColor inset;
+				box-shadow: rem(10) rem(10) rem(10) currentColor;
 			}
 		}
 	}


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Box shadows for the card links on the home page now respond to the current link color.

## Steps to test

1. Go to the home page;
2. Open UIO and test each contrast theme.

**Expected behavior:** <!-- What should happen -->

The box shadows around link cards respond to the current link color.