### PR TITLE
fix: adjusted padding and margin for header nav links (resolves #325)

### DIFF
--- a/src/scss/layout/_header.scss
+++ b/src/scss/layout/_header.scss
@@ -119,7 +119,7 @@ header {
 @media screen and (min-width: rem(1024)) {
 	header {
 		.search-container {
-			margin-left: rem(80);
+			margin-left: rem(64);
 
 			svg {
 				margin: rem(-40);
@@ -148,7 +148,7 @@ header {
 					justify-content: space-between;
 					margin: auto;
 					max-width: $max-width-margins;
-					padding: 0 rem(16);
+					padding: 0 rem(8);
 				}
 
 				nav.primary-nav {
@@ -165,8 +165,8 @@ header {
 					a {
 						border-bottom: none;
 						float: none;
-						margin: rem(24);
-						padding: rem(8) rem(10);
+						margin: rem(24) rem(8);
+						padding: rem(8) rem(5);
 					}
 
 					// When the user is in a section (other than the Home page), underline this particular item


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Adjusted margin and padding of header nav links to stop overflow of header nav search in iPad Pro view
<!-- Description of the pull request -->

## Steps to test

1. Go to deploy preview
2. Inspect page in iPad Pro view
3. Observe header nav search

**Expected behavior:** <!-- What should happen -->
Ensure header nav search is not overflowing outside of header nav.
## Additional information
N/A
<!-- Please provide any additional information that can help us review your contribution. -->

## Related issues
resolves #325 
<!-- If this pull request resolves an issue, please indicate the issue number here, e.g. 'Resolves #42' -->
