### PR TITLE
fix: provide proper names for expand buttons on the "Views" landing page (resolves #328)

### DIFF
--- a/src/_includes/components/filter.njk
+++ b/src/_includes/components/filter.njk
@@ -1,9 +1,9 @@
 <div class="filter">
 	<div class="filter-header">
 		<h2>{{ filterTitle}}</h2>
-		<button type="button" class="filter-expand-button" aria-expanded="false">
-			<svg class="arrowdown"><use xlink:href="#arrowdown" /></svg>
-			<svg class="arrowup"><use xlink:href="#arrowup" /></svg>
+		<button type="button" class="filter-expand-button" aria-expanded="false" aria-label="expand">
+			<svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
+			<svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
 		</button>
 	</div>
 

--- a/src/js/views-dynamic-handler.js
+++ b/src/js/views-dynamic-handler.js
@@ -105,6 +105,7 @@ for (let i = 0; i < expandButtons.length; i++) {
 		const currentExpandedValue = expandButtons[i].getAttribute("aria-expanded");
 		const expandedState = currentExpandedValue === "true" ? "false" : "true";
 		expandButtons[i].setAttribute("aria-expanded", expandedState);
+		expandButtons[i].setAttribute("aria-label", expandedState === "true" ? "collapse" : "expand");
 
 		// Open/close the filter
 		// Find the form filter by using its relative position with the button instead of a css selector is to work around

--- a/src/views.njk
+++ b/src/views.njk
@@ -67,9 +67,9 @@ pagination:
       <div class="filter">
       	<div class="filter-header">
       		<h2>Tags Filters</h2>
-      		<button type="button" class="filter-expand-button" aria-expanded="true">
-      			<svg class="arrowdown"><use xlink:href="#arrowdown" /></svg>
-      			<svg class="arrowup"><use xlink:href="#arrowup" /></svg>
+      		<button type="button" class="filter-expand-button" aria-expanded="true" aria-label="collapse">
+      			<svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
+      			<svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>
       		</button>
       	</div>
 


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Provide proper names for expand buttons on the "Views" landing page.

## Steps to test

1. Go to "Views";
2. Use screen reader (for example VoiceOver on Mac) to check the name of expand buttons are correctly read after performing expanding or collapsing actions;
3. Run lighthouse report for this page, the accessibility score should be 100.

**Expected behavior:** <!-- What should happen -->

See above.