### PR TITLE
fix: uio button and its panel are in the same viewport as the main page (resolves #326)

### DIFF
--- a/src/scss/vendors/_vendors.scss
+++ b/src/scss/vendors/_vendors.scss
@@ -2,6 +2,11 @@
 
 // *** UIO ***
 
+.flc-prefsEditor-separatedPanel {
+	margin: auto;
+	max-width: rem(1600);
+}
+
 // UIO button style by default
 #defaultContainer .fl-prefsEditor-separatedPanel .fl-panelBar {
 	border-bottom: none;


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

UIO button and its panel will be in the same viewport width as the main page.

## Steps to test

1. Go to any page and use responsive design mode to set a large screen width such as 3000;
2. UIO button should be above the search container on the nav bar;
3. Open UIO;
4. The UIO panel should use the similar viewport width as the main page.

**Expected behavior:** <!-- What should happen -->

See above.