### PR TITLE
fix: anchored uio tab above hearder nav search bar (resolves #332)

### DIFF
--- a/src/scss/vendors/_vendors.scss
+++ b/src/scss/vendors/_vendors.scss
@@ -2,7 +2,7 @@
 
 // *** UIO ***
 
-.flc-prefsEditor-separatedPanel {
+.fl-panelBar-wideScreen {
 	margin: auto;
 	max-width: rem(1600);
 }


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [ ] This isn't a duplicate of an existing pull request

## Description
Prevents UIO panel from being cut off as width of screen increases.
<!-- Description of the pull request -->

## Steps to test

1. Go to deploy preview
2. Inspect webpage in responsive view
3. Click on the UIO tab at the top of the webpage (it has the text _+ show preference_)
4. Expand the width of the screen to greater than 3000px
5. View the UIO panel

**Expected behavior:** <!-- What should happen -->
UIO panel should fill the width of the screen.
## Additional information

N/A

## Related issues
resolves #332
<!-- If this pull request resolves an issue, please indicate the issue number here, e.g. 'Resolves #42' -->
