### PR TITLE
fix: applied inline flex to tag fiter label span (resolves #338)

### DIFF
--- a/src/scss/components/_filter.scss
+++ b/src/scss/components/_filter.scss
@@ -133,6 +133,10 @@
 
 	.apply-button,
 	.reset-button {
+		span {
+			display: inline-flex;
+		}
+
 		&:focus,
 		&:hover {
 			svg {


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description
Tag filter button labels appears on single for all screen sizes.
<!-- Description of the pull request -->

## Steps to test

1. Go to deploy preview
2. Navigate to views page
3. Inspect page using Galaxy Fold screen
4. Observe tag filter button labels 

**Expected behavior:** <!-- What should happen -->
Tag filter button labels should occupy a single line.
## Additional information
N/A
<!-- Please provide any additional information that can help us review your contribution. -->

## Related issues

<!-- If this pull request resolves an issue, please indicate the issue number here, e.g. 'Resolves #42' -->
resolves #338 