### PR TITLE
large heading not readable in mobile view (resolved#345)

### DIFF
--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -125,3 +125,9 @@ button::before:not(.fl-prefsEditor-buttons) button {
 		}
 	}
 }
+
+@media screen and (min-width: 320px) and (max-width: 568px) {
+	.title {
+		font-size: 2rem;
+	}
+}


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description
The size of the h1 (Which is "Creating an inclusive data ecosystem") is two large not readable in mobile view ###the changed to be small.......

## Steps to test
Steps to reproduce the behavior:

1. Go to 'https://wecount.inclusivedesign.ca/'
2. Click on 'homepage'
3. See error

###screenshot before--
![h1 eerr](https://user-images.githubusercontent.com/65535360/88533406-ebfed280-d023-11ea-8800-b1026aacade3.PNG)

###after--
![h1 fixed](https://user-images.githubusercontent.com/65535360/88533440-f4570d80-d023-11ea-8617-856b39ee39a9.PNG)


## Additional information
i fixed this issue plz view my pr
@cindyli @greatislander @gtirloni 

## Related issues
#345 
