### PR TITLE
fix: improve the text for "search filters" on the views landing page

### DIFF
--- a/src/_includes/components/filter.njk
+++ b/src/_includes/components/filter.njk
@@ -1,6 +1,6 @@
 <div class="filter">
 	<div class="filter-header">
-		<h2>{{ filterTitle}}</h2>
+		<h2 class="h3">{{ filterTitle}}</h2>
 		<button type="button" class="filter-expand-button" aria-expanded="false" aria-label="expand">
 			<svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
 			<svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>

--- a/src/views.njk
+++ b/src/views.njk
@@ -34,7 +34,7 @@ pagination:
       {% set ariaLabelForSearch = "Enter keywords for a search in posts" %}
       {% include 'components/search-container.njk' %}
 
-      {% set filterTitle = "Tags Filters" %}
+      {% set filterTitle = "Search Filters" %}
       {% set filterAction = "/views/" %}
       {% include 'components/filter.njk' %}
     </form>
@@ -66,7 +66,7 @@ pagination:
       {# Filter #}
       <div class="filter">
       	<div class="filter-header">
-      		<h2>Tags Filters</h2>
+      		<h2 class="h3">Search Filters</h2>
       		<button type="button" class="filter-expand-button" aria-expanded="true" aria-label="collapse">
       			<svg class="arrowdown" aria-label="hidden"><use xlink:href="#arrowdown" /></svg>
       			<svg class="arrowup" aria-label="hidden"><use xlink:href="#arrowup" /></svg>


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Improve the appearance and text for the "Search Filters" on the views landing page.

## Steps to test

1. Go to Views landing page and check the title of "Search Filters";
2. The appearance is in h3 style;
3. Search/Filter and check again.

**Expected behavior:** <!-- What should happen -->

1. Text should be "Search Filters";
2. The appearance is in h3 style.