### PR TITLE
added the border to the elements of navbar

### DIFF
--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -125,3 +125,9 @@ button::before:not(.fl-prefsEditor-buttons) button {
 		}
 	}
 }
+
+@media screen and (min-width: 320px) and (max-width: 568px) {
+	.title {
+		font-size: 2rem;
+	}
+}

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -131,3 +131,7 @@ button::before:not(.fl-prefsEditor-buttons) button {
 		font-size: 2rem;
 	}
 }
+
+.primary-nav a {
+	border-radius: 20px;
+}

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -126,12 +126,6 @@ button::before:not(.fl-prefsEditor-buttons) button {
 	}
 }
 
-@media screen and (min-width: 320px) and (max-width: 568px) {
-	.title {
-		font-size: 2rem;
-	}
-}
-
 .primary-nav a {
 	border-radius: 20px;
 }


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

added the border radius to the elements of navbar while hovar
see in the screenshot given below for the better understanding.......

## Steps to test

1. go to the wecount website
2.  over on the elements of the navbar

### screenshot before --
![now ft](https://user-images.githubusercontent.com/65535360/88759185-d73b4f80-d187-11ea-8d14-84c2c66de2a0.PNG)

after---
![now](https://user-images.githubusercontent.com/65535360/88759432-63e60d80-d188-11ea-8743-d14bb5b323ca.PNG)




## Related issues
#351 

@cindyli  plz  view this pr