### PR TITLE
fix: add hanging indent for label texts in the search filter (resolves #354)

### DIFF
--- a/src/scss/components/_filter.scss
+++ b/src/scss/components/_filter.scss
@@ -108,6 +108,13 @@
 
 		li {
 			padding: rem(4) rem(8);
+
+			// Hanging indent for label texts
+			label {
+				display: block;
+				padding-left: rem(29);
+				text-indent: rem(-30);
+			}
 		}
 	}
 


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Long label texts on the search filter now have hanging indent.

## Steps to test

1. Go to the views landing page, open "search filter";
2. Switch to mobile view;
3. Long labels are displayed in multiple lines should have hanging indent after the first line;
4. Test with UIO settings; the hanging indent should be maintained.

**Expected behavior:** <!-- What should happen -->

See above.