### PR TITLE
Hyphenate words displayed on multiple lines FIXED FOR (footer)

### DIFF
--- a/src/_includes/components/contact-info.njk
+++ b/src/_includes/components/contact-info.njk
@@ -11,7 +11,7 @@
 	<h2>Contact Us</h2>
 	<div>
 		<address>
-			<a href="mailto:wecount@inclusivedesign.ca">wecount@inclusivedesign.ca</a><br>
+			<a href="mailto:wecount@inclusivedesign.ca">wecount@inclusiv&shy;edesign.ca</a><br>
 			IDRC<br>
 			205 Richmond Street West<br>
 			Toronto, ON M5V 1V3

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -125,3 +125,9 @@ button::before:not(.fl-prefsEditor-buttons) button {
 		}
 	}
 }
+
+@media screen and (min-width: 320px) and (max-width: 568px) {
+	.title {
+		font-size: 2rem;
+	}
+}

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -131,3 +131,7 @@ button::before:not(.fl-prefsEditor-buttons) button {
 		font-size: 2rem;
 	}
 }
+
+.primary-nav a {
+	border-radius: 20px;
+}

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -126,12 +126,6 @@ button::before:not(.fl-prefsEditor-buttons) button {
 	}
 }
 
-@media screen and (min-width: 320px) and (max-width: 568px) {
-	.title {
-		font-size: 2rem;
-	}
-}
-
 .primary-nav a {
 	border-radius: 20px;
 }


### PR DESCRIPTION
* [ ] This pull request has been linted by running `npm run lint` without errors
* [ ] This pull request has been tested by running `npm run start` and reviewing affected routes
* [ ] This pull request has been built by running `npm run build` without errors
* [ ] This isn't a duplicate of an existing pull request

## Description
 ### when we  set text style to "Open Dyslexic", enable "enhance inputs" and "syllables"; there is no hypen in the ### footer of the gmail so i fixed this .......

_fixed_ in all types of devices you can check

## Steps to test

1. go to deploy preview
2. then go to footer and set text style to "Open Dyslexic", enable "enhance inputs" and "syllables";

### screenshot before-
![now fixed](https://user-images.githubusercontent.com/65535360/89127862-c59ed280-d50e-11ea-90f6-740858db13c0.PNG)

### after-
![fixed](https://user-images.githubusercontent.com/65535360/89127868-cc2d4a00-d50e-11ea-9e67-b19e33d05fa3.PNG)



## Related issues
#256 fixed only 2 part  see in the screenshot for 2 part



