### PR TITLE
Feat: Implement the Initiatives page by fetching data from Airtable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Test and build
+name: Test
 
 on: [push, pull_request]
 
@@ -12,10 +12,9 @@ jobs:
       with:
         path: node_modules
         key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
-    - name: npm install, build, and test
+    - name: npm lint and install
       run: |
+        npm run lint
         npm ci
-        npm test
-        npm run build
       env:
         CI: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,10 @@ jobs:
         path: node_modules
         key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
     - name: npm install and lint
-      run: |
-        npm ci
-        npm run lint
-        npm run build "$AIRTABLE_API_KEY"
       env:
         CI: true
         AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
+      run: |
+        npm ci
+        npm run lint
+        npm run build "$AIRTABLE_API_KEY" "$CI"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,6 @@ jobs:
     - name: npm install and lint
       env:
         CI: true
-        AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
       run: |
         npm ci
         npm run lint
-        npm run build "$AIRTABLE_API_KEY" "$CI"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,5 +16,7 @@ jobs:
       run: |
         npm ci
         npm run lint
+        npm run build "$AIRTABLE_API_KEY"
       env:
         CI: true
+        AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,9 @@ jobs:
       with:
         path: node_modules
         key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
-    - name: npm lint and install
+    - name: npm install and lint
       run: |
-        npm run lint
         npm ci
+        npm run lint
       env:
         CI: true

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -4,7 +4,8 @@ const errorOverlay = require("eleventy-plugin-error-overlay");
 const pluginSass = require("eleventy-plugin-sass");
 const fs = require("fs");
 
-const dataFetcher = require("./src/utils/data-fetcher.js");
+const dataFetcherWp = require("./src/utils/data-fetcher-wp.js");
+const dataFetcherAirtable = require("./src/utils/data-fetcher-airtable.js");
 const htmlMinifyTransform = require("./src/transforms/html-minify.js");
 const parseTransform = require("./src/transforms/parse.js");
 const dateFilter = require("./src/filters/date.js");
@@ -20,19 +21,23 @@ module.exports = function(eleventyConfig) {
 
 	// Add custom collections.
 	eleventyConfig.addCollection("pages", async function() {
-		return dataFetcher.sitePages();
+		return dataFetcherWp.sitePages();
+	});
+
+	eleventyConfig.addCollection("workshops", async function() {
+		return dataFetcherAirtable.workshops();
 	});
 
 	eleventyConfig.addCollection("news", async function() {
-		return dataFetcher.categorizedItems("news", 8);
+		return dataFetcherWp.categorizedItems("news", 8);
 	});
 
 	eleventyConfig.addCollection("views", async function() {
-		return dataFetcher.categorizedItems("views", 1);
+		return dataFetcherWp.categorizedItems("views", 1);
 	});
 
 	eleventyConfig.addCollection("viewsTags", async function() {
-		const viewsPromise = dataFetcher.categorizedItems("views", 1);
+		const viewsPromise = dataFetcherWp.categorizedItems("views", 1);
 		return new Promise((resolve) => {
 			viewsPromise.then(views => {
 				resolve(getUniqueTags(views));
@@ -41,8 +46,8 @@ module.exports = function(eleventyConfig) {
 	});
 
 	eleventyConfig.addCollection("tags", async function() {
-		const tags = await dataFetcher.siteTags();
-		const posts = await dataFetcher.sitePosts();
+		const tags = await dataFetcherWp.siteTags();
+		const posts = await dataFetcherWp.sitePosts();
 		const pageSize = 10;
 		let collectionTogo = [];
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,12 +3,6 @@
   publish = "dist"
   functions = "functions"
 
-[dev]
-  command = "npm run start"
-  targetPort = 3000
-  publish = "dist"
-  autoLaunch = true
-
 [[redirects]]
   from = "/api/*"
   to = "/.netlify/functions/:splat"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1246,6 +1246,70 @@
         "indent-string": "^4.0.0"
       }
     },
+    "airtable": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/airtable/-/airtable-0.8.1.tgz",
+      "integrity": "sha512-Cxw55ta1olDwDERz++HFJOBX6LONtg+d7+wOcYguqI4PR4P5RHmgjTbY8tPKgLHb8U3FVOyAbpb7NpLRSnLGgg==",
+      "requires": {
+        "es6-promise": "4.2.8",
+        "lodash": "4.17.15",
+        "request": "2.88.0",
+        "xhr": "2.3.3"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
+      }
+    },
     "ajv": {
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
@@ -3310,6 +3374,11 @@
         }
       }
     },
+    "dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
     "domelementtype": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
@@ -3689,8 +3758,7 @@
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-promisify": {
       "version": "5.0.0",
@@ -5113,6 +5181,15 @@
         "unique-stream": "^2.0.2"
       }
     },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
+      }
+    },
     "global-dirs": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -6286,6 +6363,11 @@
       "requires": {
         "number-is-nan": "^1.0.0"
       }
+    },
+    "is-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
     "is-glob": {
       "version": "4.0.1",
@@ -7774,6 +7856,14 @@
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "requires": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -8761,6 +8851,11 @@
       "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
       "dev": true
     },
+    "parse-headers": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
+      "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -9268,6 +9363,11 @@
       "requires": {
         "parse-ms": "^0.1.0"
       }
+    },
+    "process": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -13052,6 +13152,17 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
+    },
+    "xhr": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.3.3.tgz",
+      "integrity": "sha1-rWuBDgkXznK17HBPXUHxUDuOdSQ=",
+      "requires": {
+        "global": "~4.3.0",
+        "is-function": "^1.0.1",
+        "parse-headers": "^2.0.0",
+        "xtend": "^4.0.0"
+      }
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@11ty/eleventy": "^0.11.0",
     "@11ty/eleventy-plugin-rss": "^1.0.7",
+    "airtable": "^0.8.1",
     "eleventy-plugin-sass": "^1.0.0",
     "infusion": "3.0.0-dev.20200525T134420Z.23c88e1ba.UIO-WeCount",
     "sanitize.css": "^11.0.1",

--- a/src/_data/env.js
+++ b/src/_data/env.js
@@ -1,5 +1,6 @@
 module.exports = {
-	api: process.env.CONTEXT === "production" ? "https://wecount-cms.inclusivedesign.ca/wp-json/wp/v2" : "https://wecount-dev.inclusivedesign.ca/wp-json/wp/v2",
+	wpApi: process.env.CONTEXT === "production" ? "https://wecount-cms.inclusivedesign.ca/wp-json/wp/v2" : "https://wecount-dev.inclusivedesign.ca/wp-json/wp/v2",
+	airtableBase: process.env.CONTEXT === "production" ? "appQ6MnPwuBsANUn0" : "appalfcvZ68ydXxx5",
 	context: process.env.CONTEXT || "dev",
 	baseUrl: process.env.DEPLOY_PRIME_URL || false
 };

--- a/src/_includes/components/nav-menu.njk
+++ b/src/_includes/components/nav-menu.njk
@@ -4,6 +4,7 @@
     <a {% if page.url === '/' + pageItem.slug + '/' %}aria-current="page" {% endif %}href="/{{ pageItem.slug }}/">{{ pageItem.title }}</a>
     {%- endif %}
   {%- endfor %}
+  <a {% if page.url === '/initiatives/' %}aria-current="page" {% endif %}href="/initiatives/">Initiatives</a>
   <a {% if page.url === '/news/' %}aria-current="page" {% endif %}href="/news/">News</a>
   <a {% if page.url === '/views/' %}aria-current="page" {% endif %} href="/views/">Views</a>
 </nav>

--- a/src/_includes/components/workshop.njk
+++ b/src/_includes/components/workshop.njk
@@ -1,8 +1,10 @@
 <article class="workshop">
-	<h2>{{ workshop.title }}</h2>
+	<h2>{{ workshop.title | safe }}</h2>
 	{% if workshop.imageUrl %}
-	<img src="{{ workshop.imageUrl | safe }}" alt="{{ workshop.altTag }}">
+	<a href="/initiative/{{ workshop.id }}">
+		<img class="workshop-image" src="{{ workshop.imageUrl | safe }}" alt="{{ workshop.imageAlt }}">
+	</a>
 	{% endif %}
 
-	<div class="description">{{ workshop.shortDescription }}</div>
+	<div class="description">{{ workshop.shortDescription | safe }}</div>
 </article>

--- a/src/_includes/components/workshop.njk
+++ b/src/_includes/components/workshop.njk
@@ -1,0 +1,8 @@
+<article class="workshop">
+	<h2>{{ workshop.title }}</h2>
+	{% if workshop.imageUrl %}
+	<img src="{{ workshop.imageUrl | safe }}" alt="{{ workshop.altTag }}">
+	{% endif %}
+
+	<div class="description">{{ workshop.shortDescription }}</div>
+</article>

--- a/src/initiatives.njk
+++ b/src/initiatives.njk
@@ -1,0 +1,30 @@
+---
+title: Initiatives
+permalink: /initiatives/
+---
+{% extends 'layouts/base.njk' %}
+
+{% block content %}
+	<article class="initiatives">
+		<h1>Initiatives</h1>
+    <p>We Count has a lot of things on the go. You can learn and co-create with us. Here are some of our upcoming and recent activities.</p>
+		<div>
+			{% for workshop in collections.workshops %}
+			<div class="api-content">
+			{% include 'components/workshop.njk' %}
+			</div>
+			{% endfor %}
+		</div>
+	</article>
+{% endblock %}
+
+{% block footerScripts %}
+<script src="/js/content-header-observer.js"></script>
+<script>
+	// Track all h1 and h2 in content for the About and Inclusion Challenges page.
+document.querySelectorAll("main article.page h1, main article.page h2, header").forEach((section) => {
+	const contentHeaderObserver = getSideMenuObserver();
+	contentHeaderObserver.observe(section);
+});
+</script>
+{% endblock %}

--- a/src/initiatives.njk
+++ b/src/initiatives.njk
@@ -22,7 +22,7 @@ permalink: /initiatives/
 <script src="/js/content-header-observer.js"></script>
 <script>
 	// Track all h1 and h2 in content for the About and Inclusion Challenges page.
-document.querySelectorAll("main article.page h1, main article.page h2, header").forEach((section) => {
+document.querySelectorAll("main article.initiatives h1, main article.initiatives h2, header").forEach((section) => {
 	const contentHeaderObserver = getSideMenuObserver();
 	contentHeaderObserver.observe(section);
 });

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -164,6 +164,16 @@
 		}
 	}
 
+	// The Initiatives page
+	.initiatives {
+		a:focus,
+		a:hover {
+			img {
+				box-shadow: rem(-10) rem(10) rem(10) currentColor;
+			}
+		}
+	}
+
 	// Focus/hover styles for SVGs on the footer
 	footer .footer-content {
 		// Logos on the footer

--- a/src/scss/components/_components.scss
+++ b/src/scss/components/_components.scss
@@ -3,6 +3,7 @@
 @import "brand";
 @import "cards";
 @import "filter";
+@import "initiatives";
 @import "news-and-views";
 @import "pagination";
 @import "post-article";

--- a/src/scss/components/_initiatives.scss
+++ b/src/scss/components/_initiatives.scss
@@ -1,0 +1,16 @@
+.initiatives {
+	.workshop {
+		padding: 0;
+
+		a:focus,
+		a:hover {
+			img {
+				box-shadow: rem(-10) rem(10) rem(10) rgba(0, 0, 0, 0.25);
+			}
+		}
+
+		.workshop-image {
+			max-width: 100%;
+		}
+	}
+}

--- a/src/transforms/parse.js
+++ b/src/transforms/parse.js
@@ -9,9 +9,9 @@ module.exports = function(value, outputPath) {
 		});
 
 		const document = DOM.window.document;
-		const articleHeadings = [
-			...document.querySelectorAll("main article.post-article h1, main article.page h1, main article.post-article h2, main article.page h2")
-		];
+		const articleHeadings = [...document.querySelectorAll(
+			"main article.post-article h1, main article.post-article h2, main article.page h1, main article.page h2, main article.initiatives h1, main article.initiatives h2"
+		)];
 
 		if (articleHeadings.length) {
 			const toc = document.querySelector("aside#toc");

--- a/src/utils/data-fetcher-airtable.js
+++ b/src/utils/data-fetcher-airtable.js
@@ -1,4 +1,5 @@
 // Communicate with Airtable APIs to access data
+const env = require("../_data/env");
 const airtable = require("airtable");
 var md = require("markdown-it")({
 	breaks: true
@@ -8,7 +9,7 @@ airtable.configure({
 	apiKey: process.env.AIRTABLE_API_KEY
 });
 
-var base = airtable.base("appalfcvZ68ydXxx5");
+var base = airtable.base(env.airtableBase);
 
 // Share data fetch functions
 module.exports = {

--- a/src/utils/data-fetcher-airtable.js
+++ b/src/utils/data-fetcher-airtable.js
@@ -4,7 +4,7 @@ var md = require("markdown-it")({
 	breaks: true
 });
 
-console.log("process.env: ", process.env);
+console.log("process.env.AIRTABLE_API_KEY: ", process.env.AIRTABLE_API_KEY);
 airtable.configure({
 	apiKey: process.env.AIRTABLE_API_KEY
 });

--- a/src/utils/data-fetcher-airtable.js
+++ b/src/utils/data-fetcher-airtable.js
@@ -1,6 +1,9 @@
 // Communicate with Airtable APIs to access data
 const ApiKey = process.env.AIRTABLE_API_KEY;
 const airtable = require("airtable");
+var md = require("markdown-it")({
+	breaks: true
+});
 
 airtable.configure({
 	apiKey: ApiKey
@@ -20,14 +23,18 @@ module.exports = {
 			}).eachPage(function page(records, fetchNextPage) {
 				records.forEach(record => {
 					let image = record.get("image");
+					let title = record.get("title");
+					let shortDescription = record.get("short_description");
+					let fullDescription = record.get("full_description");
+
 					workshops.push({
 						id: record.getId(),
-						title: record.get("title"),
+						title: title ? md.render(title) : undefined,
 						date: record.get("date"),
-						shortDescription: record.get("shortDescription"),
-						fullDescription: record.get("fullDescription"),
+						shortDescription: shortDescription ? md.render(shortDescription) : undefined,
+						fullDescription: fullDescription ? md.render(fullDescription) : undefined,
 						imageUrl: image ? image[0].url : undefined,
-						altTag: record.get("altTag")
+						imageAlt: record.get("image_alt")
 					});
 				});
 				fetchNextPage();

--- a/src/utils/data-fetcher-airtable.js
+++ b/src/utils/data-fetcher-airtable.js
@@ -8,7 +8,6 @@ airtable.configure({
 	apiKey: process.env.AIRTABLE_API_KEY
 });
 
-console.log("process.env: ", process.env);
 var base = airtable.base("appalfcvZ68ydXxx5");
 
 // Share data fetch functions

--- a/src/utils/data-fetcher-airtable.js
+++ b/src/utils/data-fetcher-airtable.js
@@ -4,7 +4,6 @@ var md = require("markdown-it")({
 	breaks: true
 });
 
-console.log("process.env.AIRTABLE_API_KEY: ", process.env.AIRTABLE_API_KEY);
 airtable.configure({
 	apiKey: process.env.AIRTABLE_API_KEY
 });

--- a/src/utils/data-fetcher-airtable.js
+++ b/src/utils/data-fetcher-airtable.js
@@ -1,12 +1,11 @@
 // Communicate with Airtable APIs to access data
-const ApiKey = process.env.AIRTABLE_API_KEY;
 const airtable = require("airtable");
 var md = require("markdown-it")({
 	breaks: true
 });
 
 airtable.configure({
-	apiKey: ApiKey
+	apiKey: process.env.AIRTABLE_API_KEY
 });
 
 var base = airtable.base("appalfcvZ68ydXxx5");

--- a/src/utils/data-fetcher-airtable.js
+++ b/src/utils/data-fetcher-airtable.js
@@ -4,6 +4,7 @@ var md = require("markdown-it")({
 	breaks: true
 });
 
+console.log("process.env: ", process.env);
 airtable.configure({
 	apiKey: process.env.AIRTABLE_API_KEY
 });

--- a/src/utils/data-fetcher-airtable.js
+++ b/src/utils/data-fetcher-airtable.js
@@ -8,6 +8,7 @@ airtable.configure({
 	apiKey: process.env.AIRTABLE_API_KEY
 });
 
+console.log("process.env: ", process.env);
 var base = airtable.base("appalfcvZ68ydXxx5");
 
 // Share data fetch functions

--- a/src/utils/data-fetcher-airtable.js
+++ b/src/utils/data-fetcher-airtable.js
@@ -1,0 +1,45 @@
+// Communicate with Airtable APIs to access data
+const ApiKey = process.env.AIRTABLE_API_KEY;
+const airtable = require("airtable");
+
+airtable.configure({
+	apiKey: ApiKey
+});
+
+var base = airtable.base("appalfcvZ68ydXxx5");
+
+// Share data fetch functions
+module.exports = {
+	workshops: async () => {
+		return new Promise((resolve) => {
+			const workshops = [];
+
+			base("workshops").select({
+				view: "Grid view",
+				sort: [{field: "date", direction: "desc"}]
+			}).eachPage(function page(records, fetchNextPage) {
+				records.forEach(record => {
+					let image = record.get("image");
+					workshops.push({
+						id: record.getId(),
+						title: record.get("title"),
+						date: record.get("date"),
+						shortDescription: record.get("shortDescription"),
+						fullDescription: record.get("fullDescription"),
+						imageUrl: image ? image[0].url : undefined,
+						altTag: record.get("altTag")
+					});
+				});
+				fetchNextPage();
+			}, function done(err) {
+				if (err) {
+					console.error("Error reading 'workshops' table from Airtable: ", err);
+					return;
+				}
+				else {
+					resolve(workshops);
+				}
+			});
+		});
+	}
+};

--- a/src/utils/data-fetcher-wp.js
+++ b/src/utils/data-fetcher-wp.js
@@ -14,7 +14,7 @@ module.exports = {
 		// 1. Fetch 100 records per page (the maxium number per page supported by Wordpress) to fasten the query
 		// 2. Retrieve embedded resources in the main query
 		// 3. Order by the published date in descending order
-		const baseCategoryAPI = env.api + "/posts?categories=" + categoryId + "&per_page=100&orderby=date&order=desc&_embed";
+		const baseCategoryAPI = env.wpApi + "/posts?categories=" + categoryId + "&per_page=100&orderby=date&order=desc&_embed";
 
 		// Fetch records for the first page as well as the number of total pages
 		const firstPageRequest = baseCategoryAPI + "&page=1";
@@ -39,7 +39,7 @@ module.exports = {
 		// 1. Fetch 100 records per page (the maxium number per page supported by Wordpress) to fasten the query
 		// 2. Retrieve embedded resources in the main query
 		// 3. Order by the published date in descending order
-		const baseCategoryAPI = env.api + "/posts?per_page=100&orderby=date&order=desc&_embed";
+		const baseCategoryAPI = env.wpApi + "/posts?per_page=100&orderby=date&order=desc&_embed";
 
 		// Fetch records for the first page as well as the number of total pages
 		const firstPageRequest = baseCategoryAPI + "&page=1";
@@ -72,7 +72,7 @@ module.exports = {
 
 		// According to the Wordpress API for pagination and embedding: https://developer.wordpress.org/rest-api/using-the-rest-api/pagination/
 		// 1. Fetch 100 records per page (the maxium number per page supported by Wordpress) to fasten the query
-		const baseTagsAPI = env.api + "/tags?per_page=100";
+		const baseTagsAPI = env.wpApi + "/tags?per_page=100";
 
 		// Fetch records for the first page as well as the number of total pages
 		const firstPageRequest = baseTagsAPI + "&page=1";
@@ -96,7 +96,7 @@ module.exports = {
 		// According to the Wordpress API for pagination and embedding: https://developer.wordpress.org/rest-api/using-the-rest-api/pagination/,
 		// 1. fetch 100 records per page (the maxium number per page supported by Wordpress) to fasten the query
 		// 2. Order by the menu order in ascending order
-		const pageAPI = env.api + "/pages?per_page=100&order=asc&orderby=menu_order";
+		const pageAPI = env.wpApi + "/pages?per_page=100&order=asc&orderby=menu_order";
 
 		const response = await axios.get(`${pageAPI}`);
 

--- a/src/utils/data-fetcher-wp.js
+++ b/src/utils/data-fetcher-wp.js
@@ -1,5 +1,6 @@
 /* global processPosts */
 
+// Communicate with WordPress APIs to access data
 const axios = require("axios");
 const env = require("../_data/env");
 


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Re-implement the Initiatives page by fetching data from Airtable. This is the first step for adding the comment area for each workshop.

Note that for now clicking each workshop image leads to "Page not found". The individual workshop page will be implemented under #350 ticket.

## Steps to test

1. Go to "Initiatives" page;

**Expected behavior:** <!-- What should happen -->

1. The workshops displayed on the page should be fetched from the "WeCount_DEV" table from Airtable;
2. The page layout should match [the Figma design](https://www.figma.com/file/0lcLol3X5MmOXackT2YbHJ/WeCount-website).
