### PR TITLE
Feat: Create a netlify function for saving user comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,52 @@ npm ci
 
 ## How to Run
 
-To run the website in local development mode that supports a live reload at file changes, enter the following in your
-command line:
+The website uses [Netlify Functions](https://functions.netlify.com/) to provide a server side endpoint that supports
+the save of user comments for workshops on the "Initiatives" page. To run the website in local development mode that
+supports a live reload at file changes, there are two ways to test the website with and without Netlify Functions.
+The latter is easier than the former:
+
+### Test the website with Netlify Functions
+
+1. Follow [Netlify instructions](https://docs.netlify.com/functions/build-with-javascript/#tools) to install tools for testing
+and deploying Netlify functions locally;
+2. After the tool set up, using Netlify Dev as an example, run following commands:
 
 ```bash
-# For security concerns, WECOUNT_API_KEY is only available for the WeCount team members
+# Due to security concerns, these environment variables are only available to WeCount team members
+export AIRTABLE_API_KEY=AIRTABLE_API_KEY_VALUE
+export EMAIL_FROM=EMAIL_TO_VALUE
+export EMAIL_FROM_PWD=EMAIL_FROM_PWD_VALUE
+export EMAIL_TO=EMAIL_TO_VALUE
+netlify dev
+```
+
+Look for this box in your console output:
+
+```bash
+   ┌──────────────────────────────────────────────────┐
+   │                                                  │
+   │   * Server now ready on http://localhost:64939   │
+   │                                                  │
+   └──────────────────────────────────────────────────┘
+```
+
+The website will be available at [http://localhost:3000](http://localhost:64939).
+
+### Test the website without Netlify Functions
+
+Note that the website launched via this testing method cannot save user comments to Airtable due to the absence of the
+server side save function.
+
+```bash
+# Due to security concerns, these environment variables are only available to WeCount team members
 export AIRTABLE_API_KEY=WECOUNT_API_KEY
 npm run start
 ```
 
 The website will be available at [http://localhost:3000](http://localhost:3000).
 
-## How to Test
+## How to Lint
 
 To lint JavaScript, CSS and Markdown files in the project (including JavaScript and CSS in Vue components),
 enter the following in the command line:
@@ -69,10 +103,13 @@ We use the following lint configurations:
 
 ## How to Build
 
+Note that the website launched via this build method cannot save user comments to Airtable due to the absence of the
+server side save function.
+
 To build a static version of the website, enter the following in your command line:
 
 ```bash
-# For security concerns, WECOUNT_API_KEY is only available for the WeCount team members
+# Due to security concerns, these environment variables are only available to WeCount team members
 export AIRTABLE_API_KEY=WECOUNT_API_KEY
 npm run build
 npx serve dist

--- a/functions/comments.js
+++ b/functions/comments.js
@@ -1,0 +1,112 @@
+/**
+ * Handle client requests for adding comments for workshops. This script does:
+ * 1. Save the comment to Airtable;
+ * 2. Send an email to moderator that a new comment has been posted and waiting for a review/
+ *
+ * Accepted requirements:
+ * 1. must be a POST request;
+ * 2. The incoming payload is in form/multipart MIME data format and must have values for 3 field:
+ * name, comment, workshopId
+ *
+ * The example of a curl command to test this endpoint:
+ * curl -X POST -d "name=test%20person&comment=a%20test%20comment&workshopId=recH5jhXKOYfeXYvP" [host-server]/api/comments
+ */
+
+const env = require("../src/_data/env");
+const airtable = require("airtable");
+const nodemailer = require("nodemailer");
+const qs = require("querystring");
+
+airtable.configure({
+	apiKey: process.env.AIRTABLE_API_KEY
+});
+
+const base = airtable.base(env.airtableBase);
+
+const sendEmail = () => {
+// const sendEmail = ({ timestamp, name, comment }) => {
+	var transporter = nodemailer.createTransport({
+		service: "gmail",
+		auth: {
+			user: "wecount.info@gmail.com",
+			pass: "ilpbxrvongwclvdd"
+		}
+	});
+
+	var mailOptions = {
+		from: "wecount.info@gmail.com",
+		to: "cli@ocadu.ca",
+		subject: "A new comment is posted on the WeCount website",
+		text: "Sent!"
+	};
+
+	return new Promise((resolve, reject) => {
+		transporter.sendMail(mailOptions, function(error, info){
+			if (error) {
+				console.error(error);
+				return reject(error);
+			} else {
+				console.log("Email sent: " + info.response);
+				resolve();
+			}
+		});
+	});
+};
+
+const saveComment = async ({ timestamp, name, comment, workshopId }) => {
+	return new Promise((resolve, reject) => {
+		base("comments").create([
+			{
+				"fields": {
+					"post_date": timestamp,
+					"name": name,
+					"comment": comment,
+					"workshop": [
+						workshopId
+					],
+					"reviewed": false
+				}
+			}
+		], function (err, records) {
+			if (err) {
+				console.error(err);
+				return reject(err);
+			}
+			records.forEach(function (record) {
+				console.log("saved into a new ID: ", record.getId());
+			});
+			resolve();
+		});
+	});
+};
+
+exports.handler = async function(event, context, callback) {
+	const incomingData = qs.parse(event.body);
+
+	// Reject the request when:
+	// 1. Not a POST request;
+	// 2. Doesn"t provide "name" or "comment" values
+	if (event.httpMethod !== "POST" || !incomingData["name"] || !incomingData["comment"] || !incomingData["workshopId"]) {
+		callback(null, {
+			statusCode: 400,
+			body: "Invalid HTTP request method or missing field values."
+		});
+	} else {
+		const timestamp = new Date().toISOString();
+		const data = {
+			timestamp: timestamp,
+			name: incomingData["name"],
+			comment: incomingData["comment"],
+			workshopId: incomingData["workshopId"]
+		};
+
+		await saveComment(data);
+		await sendEmail(data);
+
+		callback(null, {
+			statusCode: 200,
+			body: "Saved successfully!"
+		});
+	}
+
+};

--- a/functions/comments.js
+++ b/functions/comments.js
@@ -23,21 +23,20 @@ airtable.configure({
 
 const base = airtable.base(env.airtableBase);
 
-const sendEmail = () => {
-// const sendEmail = ({ timestamp, name, comment }) => {
+const sendEmail = ({ timestamp, name, comment }) => {
 	var transporter = nodemailer.createTransport({
 		service: "gmail",
 		auth: {
-			user: "wecount.info@gmail.com",
-			pass: "ilpbxrvongwclvdd"
+			user: process.env.EMAIL_FROM,
+			pass: process.env.EMAIL_FROM_PWD
 		}
 	});
 
 	var mailOptions = {
-		from: "wecount.info@gmail.com",
-		to: "cli@ocadu.ca",
+		from: process.env.EMAIL_FROM,
+		to: process.env.EMAIL_TO,
 		subject: "A new comment is posted on the WeCount website",
-		text: "Sent!"
+		text: "Below is the content of the new comment:\r\n\r\nPost Date: " + timestamp + "\r\nAuthor: " + name + "\r\nComment: " + comment + "\r\n\r\nWeCount Team"
 	};
 
 	return new Promise((resolve, reject) => {
@@ -108,5 +107,4 @@ exports.handler = async function(event, context, callback) {
 			body: "Saved successfully!"
 		});
 	}
-
 };

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,14 @@
   publish = "dist"
   functions = "functions"
 
+[dev]
+  command = "npm run start"
+  targetPort = 3000
+  publish = "dist"
+  autoLaunch = true
+  framework = "#custom"
+  functions = "functions"
+
 [[redirects]]
   from = "/api/*"
   to = "/.netlify/functions/:splat"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8222,6 +8222,11 @@
       "integrity": "sha512-rEwE51JWn0yN3Wl5BXeGn5d52OGbSXzWiiXRjAQeuyvcGKyvuSILW2rb3G7Xh+nexzLwhTpek6Ehxd6IjvHePg==",
       "dev": true
     },
+    "nodemailer": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.11.tgz",
+      "integrity": "sha512-BVZBDi+aJV4O38rxsUh164Dk1NCqgh6Cm0rQSb9SK/DHGll/DrCMnycVDD7msJgZCnmVa8ASo8EZzR7jsgTukQ=="
+    },
     "nopt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "airtable": "^0.8.1",
     "eleventy-plugin-sass": "^1.0.0",
     "infusion": "3.0.0-dev.20200525T134420Z.23c88e1ba.UIO-WeCount",
+    "nodemailer": "^6.4.11",
     "sanitize.css": "^11.0.1",
     "uuid": "^8.2.0"
   },

--- a/src/utils/data-fetcher-airtable.js
+++ b/src/utils/data-fetcher-airtable.js
@@ -9,7 +9,7 @@ airtable.configure({
 	apiKey: process.env.AIRTABLE_API_KEY
 });
 
-var base = airtable.base(env.airtableBase);
+const base = airtable.base(env.airtableBase);
 
 // Share data fetch functions
 module.exports = {


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

This Netlify function provides a server side endpoint to handle client requests on saving user comments:

1. The endpoint is at "/api/comments";
2. The instruction of how to use this endpoint can be found [here](https://github.com/cindyli/wecount.inclusivedesign.ca/blob/feat/save-comments/functions/comments.js#L6-L12).

This endpoint does:

1. Save the comment to Airtable;
2. Send an email to a specified email address with the comment content.

Note:

1. A gmail account "wecount.info@gmail.com" is created as the "sent-from" email address and emails are sent through Gmail servers;
2. @TeddTech, as you will review this pull request, I will temporarily set the "sent-to" email to your email address so you can review the email content.

## Steps to test

Send a POST request to the endpoint served at the preview deploy. For example:
```
curl -X POST -d "name=test%20person&comment=a%20test%20comment&workshopId=recH5jhXKOYfeXYvP" https://deploy-preview-293--wecount.netlify.app/api/comments
```

**Expected behavior:** <!-- What should happen -->

1. Check Airtable base "WeCount_DEV" to make sure the posted comment is saved in the "comments" table;
2. Make sure the email is received with proper content.
