### PR TITLE
aligned the gmail link fixed(#381)

### DIFF
--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -125,7 +125,3 @@ button::before:not(.fl-prefsEditor-buttons) button {
 		}
 	}
 }
-
-.primary-nav a {
-	border-radius: 20px;
-}

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -125,3 +125,9 @@ button::before:not(.fl-prefsEditor-buttons) button {
 		}
 	}
 }
+
+@media screen and (min-width: 320px) and (max-width: 568px) {
+	.title {
+		font-size: 2rem;
+	}
+}

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -131,3 +131,7 @@ button::before:not(.fl-prefsEditor-buttons) button {
 		font-size: 2rem;
 	}
 }
+
+.primary-nav a {
+	border-radius: 20px;
+}

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -126,12 +126,6 @@ button::before:not(.fl-prefsEditor-buttons) button {
 	}
 }
 
-@media screen and (min-width: 320px) and (max-width: 568px) {
-	.title {
-		font-size: 2rem;
-	}
-}
-
 .primary-nav a {
 	border-radius: 20px;
 }

--- a/src/scss/layout/_footer.scss
+++ b/src/scss/layout/_footer.scss
@@ -68,6 +68,7 @@ footer {
 			a {
 				color: $white;
 				font-weight: $font-weight-normal;
+				white-space: nowrap;
 
 				svg {
 					padding: rem(32) rem(16) rem(16) 0;


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description
the gmail link is gone to next line when add space to "2" and add the text-style"verdana",,,
so i fixed and do the gmail link in one line see in the screenahot for the better understanding...

## Steps to test

1. Go to deploy preview
2. changed text-style to "verdana" and add space to "2"
3. scroll down to footer gmail link


### screenshot after my code changes--
![issue fixed we count](https://user-images.githubusercontent.com/65535360/91655914-00763500-ead2-11ea-8c78-a771c29965d7.PNG)

### Screenshots before---
![issue](https://user-images.githubusercontent.com/65535360/91655870-b8571280-ead1-11ea-99a3-9e68fc610cd7.PNG)


## Additional information
gmail link should be aligned in one line as the figma designs

## Related issues
#381 