### PR TITLE
feat: blur images with missing or unhelpful alt tags

### DIFF
--- a/src/scss/layout/_layout.scss
+++ b/src/scss/layout/_layout.scss
@@ -113,6 +113,13 @@ article {
 		audio {
 			max-width: 100%;
 		}
+
+		// Blur imags which are missing alt tags altogether
+		// or whose alt tags begin with "This image has an empty alt attribute"
+		img:not([alt]),
+		img[alt^="This image has an empty alt attribute"] {
+			filter: blur(10px);
+		}
 	}
 
 	video {


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This PR implements a CSS utility to blur images which have either a missing alt tag or an alt tag beginning with `This image has an empty alt attribute` (see #389). Images with alt tags which are present but empty are assumed to be decorative and are unaffected. 

## Steps to test

1. Check out this branch.
2. Run `netlify dev`.
3. Visit the badges page.

**Expected behavior:** Badge images are blurred.

## Additional information

Adapted from https://github.com/platform-coop-toolkit/pinecone/issues/230.

## Related issues

Not applicable
