### PR TITLE
fix: improve the color contrast of pagination links (resolves #397)

### DIFF
--- a/src/scss/components/_pagination.scss
+++ b/src/scss/components/_pagination.scss
@@ -31,6 +31,7 @@
 		border: 0;
 		border-radius: 100%;
 		box-shadow: 0 0 0 rem(2) $blue-alt-light inset;
+		color: $green-dark;
 		float: left;
 		font-size: rem(18);
 		font-weight: 400;


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Adjust the color of pagination links according to the figma design.

## Steps to test

1. Check [the report of "lighthouse CI - Mobile"](https://github.com/inclusive-design/wecount.inclusivedesign.ca/pull/293/checks?check_run_id=1130461284) generated by [the lighthouse CI pull request](https://github.com/inclusive-design/wecount.inclusivedesign.ca/pull/293);
2. Accessibility score of a few pagination links is dropped from 100 to 98.
3. Run lighthouse - Mobile report with pages that have problems with the fix.

**Expected behavior:** <!-- What should happen -->

Accessibility scores should be back to 100.