### PR TITLE
feat: allow to define different moderator emails for production and dev sites (resolves #403)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,15 @@ The latter is easier than the former:
 
 1. Follow [Netlify instructions](https://docs.netlify.com/functions/build-with-javascript/#tools) to install tools for testing
 and deploying Netlify functions locally;
-2. After the tool set up, using Netlify Dev as an example, run following commands:
+2. Once the tool is set up, using Netlify Dev as an example, run following commands:
 
 ```bash
 # Due to security concerns, these environment variables are only available to WeCount team members
 export AIRTABLE_API_KEY=AIRTABLE_API_KEY_VALUE
 export EMAIL_FROM=EMAIL_TO_VALUE
 export EMAIL_FROM_PWD=EMAIL_FROM_PWD_VALUE
-export EMAIL_TO=EMAIL_TO_VALUE
+export EMAIL_TO_PRODUCTION=PRODUCTION_SITE_MODERATOR_EMAIL
+export EMAIL_TO_DEV=DEV_SITE_MODERATOR_EMAIL
 netlify dev
 ```
 

--- a/functions/comments.js
+++ b/functions/comments.js
@@ -33,7 +33,7 @@ const sendEmail = ({ timestamp, name, comment }) => {
 
 	var mailOptions = {
 		from: process.env.EMAIL_FROM,
-		to: process.env.EMAIL_TO,
+		to: env.moderatorEmail,
 		subject: "A new comment is posted on the WeCount website",
 		text: "Below is the content of the new comment:\r\n\r\nPost Date: " + timestamp + "\r\nAuthor: " + name + "\r\nComment: " + comment + "\r\n\r\nWeCount Team"
 	};

--- a/src/_data/env.js
+++ b/src/_data/env.js
@@ -1,6 +1,7 @@
 module.exports = {
 	wpApi: process.env.CONTEXT === "production" ? "https://wecount-cms.inclusivedesign.ca/wp-json/wp/v2" : "https://wecount-dev.inclusivedesign.ca/wp-json/wp/v2",
 	airtableBase: process.env.CONTEXT === "production" ? "app47GBs2ANe0yVGS" : "appalfcvZ68ydXxx5",
+	moderatorEmail: process.env.CONTEXT === "production" ? process.env.EMAIL_TO_PRODUCTION : process.env.EMAIL_TO_DEV,
 	context: process.env.CONTEXT || "dev",
 	baseUrl: process.env.DEPLOY_PRIME_URL || false
 };


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Allow to define different moderator emails as environment variables for the production and the development websites.

## Steps to test

1. Follow the section "Test the website with Netlify Functions" in README to run Netlify dev environment locally. This allows the tester to use two own email addresses to test;
2. Simulate the development site and test:
* Follow commands in "Test the website with Netlify Functions" to start a simulation of a development site;
* Go to the workshop page and post a comment; 
* The email address defined in EMAIL_TO_DEV should receive an email;
* Check Airtable "WeCount_DEV" base, the new comment should appear in the "comments" table.
3. Simulate the production site and test:
* In the terminal, issue this command `export CONTEXT=production`;
* Follow commands in "Test the website with Netlify Functions" to start a simulation of a production site;
* Go to the workshop page and post a comment; 
* The email address defined in EMAIL_TO_PRODUCTION should receive an email;
* Check Airtable "WeCount" base, the new comment should appear in the "comments" table.

**Expected behavior:** <!-- What should happen -->
See above.