### PR TITLE
fix: adjust the position of images on home page tiles (resolves #411)

### DIFF
--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -9,7 +9,7 @@
 		background-position: 50% 80%;
 		background-repeat: no-repeat;
 		box-shadow: 0 rem(4) rem(4) rgba(0, 0, 0, 0.25);
-		height: rem(256);
+		height: rem(208);
 
 		&:hover,
 		&:focus {


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Decrease tile heights to move tile image positions.

@uttaraghodke, can you check image positions in this deploy preview and let me know how they look? Thanks.