### PR TITLE
fix: adjust the size of badge images (resolves #413)

### DIFF
--- a/src/scss/layout/_layout.scss
+++ b/src/scss/layout/_layout.scss
@@ -202,6 +202,7 @@ article {
 				}
 
 				img {
+					height: 100%;
 					width: 100%;
 				}
 			}


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Badge images should be smaller and displayed in proportion.

## Steps to test

1. Go to the Badges page

**Expected behavior:** <!-- What should happen -->

The size of badges images are good.

@uttaraghodke, can you take a look at badge images in the deploy preview and let me know if they look better? Thanks.