### PR TITLE
docs: rename master to main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,7 +36,7 @@ We merge all pull requests using [squash commits](https://help.github.com/en/git
 
 Issues and their corresponding pull requests will be assigned to a milestone by the development team. Once all
 of the issues in a given milestone have been resolved, the development team will close the milestone and merge the [dev][dev]
-branch into [master][master].
+branch into [main][main].
 A release will then be tagged and a changelog generated, as follows:
 
 - For [patch releases](https://semver.org/#spec-item-6), you can tag the release and generate a changelog by
@@ -49,4 +49,4 @@ running `npm run release:major`
 Only at this point will the changes in that release be [deployed to the production site](https://github.com/inclusive-design/wecount.inclusivedesign.ca#how-to-deploy).
 
 [dev]: https://github.com/inclusive-design/wecount.inclusivedesign.ca/tree/dev
-[master]: https://github.com/inclusive-design/wecount.inclusivedesign.ca/tree/master
+[main]: https://github.com/inclusive-design/wecount.inclusivedesign.ca/tree/main

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ npm run lint
 
 We use the following lint configurations:
 
-- TODO: [ESLint (JS)](https://github.com/inclusive-design/wecount.inclusivedesign.ca/blob/master/.eslintrc.js)
-- [Stylelint (CSS/SCSS)](https://github.com/inclusive-design/wecount.inclusivedesign.ca/blob/master/stylelint.config.js)
-- [MarkdownLint (Markdown)](https://github.com/inclusive-design/wecount.inclusivedesign.ca/blob/master/.markdownlint.json)
+- TODO: [ESLint (JS)](https://github.com/inclusive-design/wecount.inclusivedesign.ca/blob/main/.eslintrc.js)
+- [Stylelint (CSS/SCSS)](https://github.com/inclusive-design/wecount.inclusivedesign.ca/blob/main/stylelint.config.js)
+- [MarkdownLint (Markdown)](https://github.com/inclusive-design/wecount.inclusivedesign.ca/blob/main/.markdownlint.json)
 
 ## How to Build
 
@@ -127,7 +127,7 @@ This repository is connected to [Netlify](https://netlify.com), and commits will
 
 - Pull request #175 (for example): [https://deploy-preview-175--wecount.netlify.app](https://deploy-preview-175--wecount.netlify.app)
 - Branch `dev`: [https://dev--wecount.netlify.app](https://dev--wecount.netlify.app)
-- Branch `master`: [https://wecount.inclusivedesign.ca](https://wecount.inclusivedesign.ca)
+- Branch `main`: [https://wecount.inclusivedesign.ca](https://wecount.inclusivedesign.ca)
 
 ## License
 


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Updated references to the "master" branch to "main". I couldn't test the building of the site though because I don't have an Airtable API key.
