### PR TITLE
fix: reduce the space between h3s and their contents on the badges page (resolves #425)

### DIFF
--- a/src/page.njk
+++ b/src/page.njk
@@ -37,7 +37,7 @@ permalink: "/{{ '/' if pageItem.slug === 'home' else pageItem.slug	}}/"
 </div>
 
 {% elif pageItem.slug === 'initiatives' %}
-<article class="page">
+<article class="page {{ pageItem.slug }}">
 	<h1 class="title">{{ pageTitle }}</h1>
 	<div class="api-content">
 		{{ pageItem.content | safe }}
@@ -60,7 +60,7 @@ permalink: "/{{ '/' if pageItem.slug === 'home' else pageItem.slug	}}/"
 </article>
 
 {% else %}
-<article class="page">
+<article class="page {{ pageItem.slug }}">
 	<h1>{{ pageTitle }}</h1>
 	<div class="api-content">
 		{{ pageItem.content | safe }}

--- a/src/scss/components/_badges.scss
+++ b/src/scss/components/_badges.scss
@@ -1,6 +1,6 @@
 // CSS classes for the "Badges" page
 .badges {
 	h3 {
-		margin-bottom: 0;
+		margin-bottom: rem(-8);
 	}
 }

--- a/src/scss/components/_badges.scss
+++ b/src/scss/components/_badges.scss
@@ -1,6 +1,10 @@
 // CSS classes for the "Badges" page
 .badges {
 	h3 {
-		margin-bottom: rem(-8);
+		margin-bottom: 0;
+
+		& + div p {
+			margin-top: rem(6);
+		}
 	}
 }

--- a/src/scss/components/_badges.scss
+++ b/src/scss/components/_badges.scss
@@ -1,0 +1,6 @@
+// CSS classes for the "Badges" page
+.badges {
+	h3 {
+		margin-bottom: 0;
+	}
+}

--- a/src/scss/components/_components.scss
+++ b/src/scss/components/_components.scss
@@ -1,6 +1,7 @@
 // Component-specific styles.
 @import "advisory-panel";
 @import "aside";
+@import "badges";
 @import "brand";
 @import "cards";
 @import "filter";


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Reduce the space between h3s and their contents on the badges page.

## Steps to test

1. Go to the badges page;
2. Compare the deploy preview with the dev or production sites on the space right below h3s.

**Expected behavior:** <!-- What should happen -->

In the deploy preview, the space below h3s should be reduced to a reasonable size.
