### PR TITLE
fix: the build/deploy no longer fails when there are empty workshop records (resolves #431)

### DIFF
--- a/src/utils/data-fetcher-airtable.js
+++ b/src/utils/data-fetcher-airtable.js
@@ -19,6 +19,7 @@ module.exports = {
 
 			base("workshops").select({
 				view: "Grid view",
+				filterByFormula: "NOT({title} = '')",
 				sort: [{field: "date", direction: "desc"}]
 			}).eachPage(function page(records, fetchNextPage) {
 				records.forEach(record => {


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

The build or deploy no longer fails when there are empty workshop records.

## Steps to test

1. Go to [Airtable](https://airtable.com/) WeCount_DEV base and make sure there is at least one empty record in "workshops" table.
2. Follow [the readme instruction](https://github.com/inclusive-design/wecount.inclusivedesign.ca/#how-to-run) to build the website locally.

**Expected behavior:** <!-- What should happen -->

1. The build completes successfully.
2. Go to the Initiatives page, workshops are listed correctly.