### PR TITLE
fix: use the workshop title when the image alt text is not defined (resolves #436)

### DIFF
--- a/src/_includes/components/workshop.njk
+++ b/src/_includes/components/workshop.njk
@@ -6,7 +6,7 @@
 	<div class="workshop-image">
 		<a href="/initiatives/{{ workshop.id }}">
 			{% if workshop.previewImageUrl %}
-				<img src="{{ workshop.previewImageUrl | safe }}" alt="{{ workshop.imageAlt }}">
+				<img src="{{ workshop.previewImageUrl | safe }}" alt="{{ workshop.imageAlt if workshop.imageAlt else workshop.title }}">
 			{% else %}
 				<img src="/images/workshop.png" alt="{{ workshop.title | safe }}">
 			{% endif %}


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Use the workshop title as the alt text for the cover image when the alt text is not defined in the Airtable.

## Steps to test

1. Check Airtable to find workshop records that have cover image uploaded but the image alt text is not defined;
2. Go to the Initiatives page;
3. The workshops identified in step 1 should have their workshop title used as the alt text for cover images;
4. All workshop cover images should have alt texts;
5. Run lighthouse report;
6. The score for accessibility should be 100.

**Expected behavior:** <!-- What should happen -->

See above.