### PR TITLE
feat: adjust the styling of the advisory panel page based on the design (resolves #440)

### DIFF
--- a/src/page.njk
+++ b/src/page.njk
@@ -51,16 +51,6 @@ permalink: "/{{ '/' if pageItem.slug === 'home' else pageItem.slug	}}/"
 	</div>
 </article>
 
-{% elif pageItem.slug === "advisory-panel" or pageItem.slug === "team" %}
-<article class="{{ pageItem.slug }}">
-	{% if pageItem.slug === "team" %}
-	<h1 class="title">{{ pageTitle }}</h1>
-	{% endif %}
-	<div class="api-content">
-		{{ pageItem.content | safe }}
-	</div>
-</article>
-
 {% else %}
 <article class="page {{ pageItem.slug }}">
 	<h1>{{ pageTitle }}</h1>

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -286,7 +286,7 @@
 
 		// Advisory panel page
 		.advisory-panel > .api-content > .wp-block-group > .wp-block-group__inner-container > .wp-block-group > .wp-block-group__inner-container > .wp-block-group {
-			box-shadow: 0 rem(4) rem(4) currentColor;
+			box-shadow: rem(0) rem(0) rem(7) currentColor;
 		}
 	}
 

--- a/src/scss/components/_advisory-panel.scss
+++ b/src/scss/components/_advisory-panel.scss
@@ -7,8 +7,8 @@
 	h2:not(.h3) {
 		border-bottom: none;
 		color: $green-dark;
+		font-weight: $font-weight-semibold;
 		margin: 0;
-		text-transform: uppercase;
 	}
 
 	img {
@@ -73,9 +73,12 @@
 	// Add box shadows to bio description paragraphs
 	& > .api-content > .wp-block-group > .wp-block-group__inner-container > .wp-block-group > .wp-block-group__inner-container > .wp-block-group {
 		background-color: $white;
-		box-shadow: 0 rem(4) rem(4) rgba(0, 0, 0, 0.25);
+		border-radius: rem(10);
+		box-shadow: rem(0) rem(0) rem(7) rgba(0, 0, 0, 0.25);
 
 		& > .wp-block-group__inner-container {
+			// In order to apply border-radius, the inner element need to have the same border-radius applied.
+			border-radius: rem(10);
 			padding: rem(16);
 		}
 	}

--- a/src/scss/components/_advisory-panel.scss
+++ b/src/scss/components/_advisory-panel.scss
@@ -108,3 +108,11 @@
 		}
 	}
 }
+
+// This media query breakpoint is for the Galaxy Fold screen.
+@include breakpoint-down(xs) {
+	.api-content > .wp-block-group > .wp-block-group__inner-container > .wp-block-group > .wp-block-group__inner-container > .wp-block-group {
+		margin-left: rem(-8);
+		margin-right: rem(-8);
+	}
+}

--- a/src/transforms/parse.js
+++ b/src/transforms/parse.js
@@ -27,7 +27,11 @@ module.exports = function(value, outputPath) {
 				const tocLi = document.createElement("li");
 				const tocLink = document.createElement("a");
 				tocLink.setAttribute("href", `#${headingSlug}`);
-				tocLink.textContent = heading.textContent;
+				// Some headings on the main page are explicitly using soft hyphens (&shy;) for words to be properly hyphened on
+				// the mobile sized screens. This creates an issue that these hyphens are picked up and shown as `&shy;` on the side
+				// menu. Considering the side menu is only shown on the desktop view not on the mobile view and hyphens are unnecessary
+				// on the desktop view, these soft hyphens can be removed from the side menu.
+				tocLink.textContent = heading.textContent.replace(/&shy;/g, "");
 				tocLi.appendChild(tocLink);
 				tocUl.appendChild(tocLi);
 			});


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Adjust the styling of the advisory panel page based on [the figma design](https://www.figma.com/file/0lcLol3X5MmOXackT2YbHJ/WeCount-website?node-id=2257%3A0). Refer to [the issue](https://github.com/inclusive-design/wecount.inclusivedesign.ca/issues/440) about details to be adjusted.

## Steps to test

1. Go to the Advisory Panel page;
2. Make sure the adjusted styling matches the design;
3. Test with UIO and make sure the adjusted styling corresponds correctly.

**Expected behavior:** <!-- What should happen -->

See above.