### PR TITLE
feat: add "register here" button for workshops on the Initiatives page (resolves #441)

### DIFF
--- a/src/_includes/components/workshop.njk
+++ b/src/_includes/components/workshop.njk
@@ -2,6 +2,9 @@
 	<div class="workshop-narrative">
 		<h2 class="h3"><a href="/initiatives/{{ workshop.id }}">{{ workshop.title | safe }}</a></h2>
 		<div class="description">{{ workshop.shortDescription | safe }}</div>
+		{% if workshop.registrationUrl %}
+		<a href={{ workshop.registrationUrl }} class="registration-button">Register here</a>
+		{% endif %}
 	</div>
 	<div class="workshop-image">
 		<a href="/initiatives/{{ workshop.id }}">

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -236,8 +236,12 @@
 	.search-container input,
 	button:not(.filter-expand-button):focus,
 	button:not(.filter-expand-button):hover,
+	// The "post a comment" button on the Workshop page
 	#comment-form button,
 	#comment-form button::before,
+	// The "register here" button on the Intiatives page
+	.registration-button,
+	.registration-button::before,
 	li .pagination-link,
 	li .pagination-link::before,
 	.wp-block-file__button:focus,

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -25,7 +25,7 @@
 	}
 }
 
-// Maintain aspect ratio of a container
+// The general css for tags
 @mixin tags() {
 	display: flex;
 	flex-wrap: wrap;

--- a/src/scss/components/_initiatives.scss
+++ b/src/scss/components/_initiatives.scss
@@ -192,25 +192,25 @@
 		font-weight: $font-weight-medium;
 		margin-right: rem(20);
 	}
+}
 
-	button {
-		background-color: $white;
-		border: 0;
-		border-radius: rem(33);
-		box-shadow: 0 0 0 rem(2) $green-dark inset;
-		box-sizing: border-box;
-		color: $green-dark;
-		float: right;
-		font-size: rem(16);
-		font-weight: $font-weight-semibold;
-		height: rem(41);
-		line-height: rem(19);
-		margin: rem(29) 0;
-		padding: rem(8) rem(34);
-		transform: perspective(rem(1)) translateZ(0);
-	}
+// Button style shared by the "register here" button on the Intiatives page and the "post a comment" button on the Workshop page
+#comment-form button,
+.registration-button {
+	background-color: $white;
+	border: 0;
+	border-radius: rem(33);
+	box-shadow: 0 0 0 rem(2) $green-dark inset;
+	box-sizing: border-box;
+	color: $green-dark;
+	font-size: rem(16);
+	font-weight: $font-weight-semibold;
+	height: rem(41);
+	line-height: rem(24);
+	padding: rem(8) rem(34);
+	transform: perspective(rem(1)) translateZ(0);
 
-	button::before {
+	&::before {
 		border-radius: rem(26);
 		box-shadow: 0 0 0 rem(2) $green-dark inset;
 		content: '';
@@ -222,24 +222,40 @@
 		width: 100%;
 	}
 
-	button:hover::before,
-	button:focus::before,
-	button:active::before {
+	&:hover::before,
+	&:focus::before,
+	&:active::before {
 		left: rem(4);
 		top: rem(4);
 	}
 
-	button::-moz-focus-inner {
+	&::-moz-focus-inner {
 		outline: none;
 	}
 
-	button:focus {
+	&:focus {
 		outline: none;
 	}
 
-	button:-moz-focusring {
+	&:-moz-focusring {
 		color: transparent;
 		text-shadow: 0 0 0 $green-dark;
+	}
+}
+
+// Use higher specificity to define special style for two buttons to avoid css linting errors
+.workshop-page #comment-form button {
+	float: right;
+	margin: rem(29) 0;
+}
+
+.workshops .registration-button {
+	float: left;
+
+	&:focus,
+	&:hover,
+	&:active {
+		background-color: white;
 	}
 }
 
@@ -253,7 +269,7 @@
 			.workshop-narrative {
 				border-radius: rem(18) 0 0 rem(18);
 				min-height: rem(336);
-				padding: 0 rem(16) 0 rem(32);
+				padding: 0 rem(16) rem(16) rem(32);
 			}
 
 			// In order to apply border-radius, all inner elements need to have the same border-radius applied.
@@ -288,5 +304,9 @@
 		&::before {
 			height: rem(54);
 		}
+	}
+
+	.registration-button {
+		padding: rem(8) rem(16);
 	}
 }

--- a/src/utils/data-fetcher-airtable.js
+++ b/src/utils/data-fetcher-airtable.js
@@ -23,11 +23,12 @@ module.exports = {
 				sort: [{field: "date", direction: "desc"}]
 			}).eachPage(function page(records, fetchNextPage) {
 				records.forEach(record => {
-					let previewImage = record.get("preview_image");
-					let coverImage = record.get("cover_image");
 					let title = record.get("title");
 					let shortDescription = record.get("short_description");
 					let fullDescription = record.get("full_description");
+					let registrationUrl = record.get("registration_url");
+					let previewImage = record.get("preview_image");
+					let coverImage = record.get("cover_image");
 					let comments = [];
 
 					let workshopFilterFormula = "{recID (from workshops)} = '" + record.id + "'";
@@ -60,6 +61,7 @@ module.exports = {
 						date: record.get("date"),
 						shortDescription: shortDescription ? md.render(shortDescription) : undefined,
 						fullDescription: fullDescription ? md.render(fullDescription) : undefined,
+						registrationUrl,
 						previewImageUrl: previewImage ? previewImage[0].url : undefined,
 						coverImageUrl: coverImage ? coverImage[0].url : undefined,
 						imageAlt: record.get("image_alt"),


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Add "register here" button for workshops on the Initiatives page. The design for it can be found in [the figma](https://www.figma.com/file/0lcLol3X5MmOXackT2YbHJ/WeCount-website?node-id=1881%3A3695)

## Steps to test

1. Check Airtable "wecount_dev" base. In the "workshops" table, some workshops have URLs defined in "registration_url" field, some don't have;
2. Go to the Initiatives page, workshops have "registration_url" defined in Airtable have "register here" buttons displayed. The style of this button should match the design;
3. Test with UIO and the button should respond correctly.

**Expected behavior:** <!-- What should happen -->

See above.