### PR TITLE
feat: improve workshop preview images on the initiatives page (resolves #446)

### DIFF
--- a/src/_includes/components/workshop.njk
+++ b/src/_includes/components/workshop.njk
@@ -7,12 +7,10 @@
 		{% endif %}
 	</div>
 	<div class="workshop-image">
-		<a href="/initiatives/{{ workshop.id }}">
-			{% if workshop.previewImageUrl %}
-				<img src="{{ workshop.previewImageUrl | safe }}" alt="{{ workshop.imageAlt if workshop.imageAlt else workshop.title }}">
-			{% else %}
-				<img src="/images/workshop.png" alt="{{ workshop.title | safe }}">
-			{% endif %}
-		</a>
+		{% if workshop.previewImageUrl %}
+			<img src="{{ workshop.previewImageUrl | safe }}" {% if workshop.previewImageAltText %}alt="{{ workshop.previewImageAltText}}"{% else %}role="presentation"{% endif %}>
+		{% else %}
+			<img src="/images/workshop.png" role="presentation">
+		{% endif %}
 	</div>
 </div>

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -166,15 +166,6 @@
 		}
 	}
 
-	.workshop-image {
-		a:focus,
-		a:hover {
-			img {
-				box-shadow: 0 0 0 rem(4) currentColor inset;
-			}
-		}
-	}
-
 	// Workshop Page
 	.disabled-element,
 	.submitted-comment {

--- a/src/scss/components/_initiatives.scss
+++ b/src/scss/components/_initiatives.scss
@@ -35,21 +35,8 @@
 
 			img {
 				border-radius: 0 0 rem(18) rem(18);
-				box-shadow: 0 0 0 rem(4) transparent inset;
 				height: 100%;
-				// Add initial padding to leave room for the inset box shadow to display at focus/hover
-				padding: rem(4);
 				width: 100%;
-			}
-
-			a:focus,
-			a:hover {
-				// Override the default background-color for a:hover
-				background-color: transparent;
-
-				img {
-					box-shadow: 0 0 0 rem(4) $navy-light inset;
-				}
 			}
 		}
 	}

--- a/src/utils/data-fetcher-airtable.js
+++ b/src/utils/data-fetcher-airtable.js
@@ -63,8 +63,9 @@ module.exports = {
 						fullDescription: fullDescription ? md.render(fullDescription) : undefined,
 						registrationUrl,
 						previewImageUrl: previewImage ? previewImage[0].url : undefined,
+						previewImageAltText: record.get("preview_alt_text"),
 						coverImageUrl: coverImage ? coverImage[0].url : undefined,
-						imageAlt: record.get("image_alt"),
+						coverImageAltText: record.get("cover_alt_text"),
 						comments
 					});
 				});

--- a/src/workshop-comments.njk
+++ b/src/workshop-comments.njk
@@ -13,7 +13,7 @@ permalink: "initiatives/{{ workshopItem.id }}/"
 	<article class="workshop-page">
 		<h1>{{ workshopItem.title | safe }}</h1>
 		{% if workshopItem.coverImageUrl %}
-		<img class="workshop-cover-image" src="{{ workshopItem.coverImageUrl | safe }}" alt="{{ workshopItem.imageAlt }}">
+		<img class="workshop-cover-image" src="{{ workshopItem.coverImageUrl | safe }}" alt="{{ workshopItem.coverImageAltText }}">
 		{% endif %}
 
 		<div class="description">{{ workshopItem.fullDescription | safe }}</div>


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Applied changes described in https://github.com/inclusive-design/wecount.inclusivedesign.ca/issues/446 for the Initiatives page.

## Steps to test

1. Go to Airtable -> base "WeCount_DEV", "preview_alt_text" and "cover_alt_text" fields should be in place;
2. Go to the initiatives page, check:
* Workshop preview images are no longer links;
* For workshops that have "preview_alt_text" set in the Airtable, `alt` value for this workshop preview image should have been set to the alt value;
* For workshops that don't have "preview_alt_text" set in the Airtable, this workshop preview image tags should have `role="presentation".
3. Click on a workshop title to go to the workshop information page. Check:
* If this workshop has a cover image uploaded in the Airtable, the cover image should be displayed on the page and its alt text is set to the value that's defined in the Airtable "cover_alt_text" field;
* If the workshop doesn't have a cover image uploaded in the Airtable, nothing is shown as the cover image on this page.

**Expected behavior:** <!-- What should happen -->

See above.