### PR TITLE
fix: update the tile link to participate in challenges

### DIFF
--- a/src/page.njk
+++ b/src/page.njk
@@ -27,7 +27,7 @@ permalink: "/{{ '/' if pageItem.slug === 'home' else pageItem.slug	}}/"
 			<a href="/learn/" class="green card">
 				<h2>Find inclusive data tools</h2>
 			</a>
-			<a href="/inclusion-challenges/" class="yellow card">
+			<a href="/initiatives/" class="yellow card">
 				<h2>Participate in our inclusion challenge workshops</h2>
 			</a>
 			<a href="/badges/" class="azure card">


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

On the Home page, update the tile link of "participate in challenges" to https://wecount.inclusivedesign.ca/initiatives/.

## Steps to test

1. Click the tile on the home page

**Expected behavior:** <!-- What should happen -->

It needs to the initiatives page.