### PR TITLE
feat: views articles use author names defined in the custom author field (resolves #452)

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -62,7 +62,7 @@ processPosts = function (posts) {
 			category: categoryType,
 			slug: onePost.slug,
 			title: onePost.title.rendered,
-			author: onePost._embedded.author[0].name,
+			author: categoryType === "views" ? onePost.acf.custom_author : null,
 			content: onePost.content.rendered,
 			excerpt: onePost.excerpt.rendered,
 			dateTime: onePost.date,


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

A custom field "author" is added in WordPress for defining a different author other than the actual post creator. This only applies to posts in the Views category. This pull request is to fetch and display authors of Views posts from this custom field.

## Steps to test

1. Go to the WordPress dev site;
2. Check the author of "test post 100": the actual post author is "Cindy Li" while the custom author is "Test Author";
3. Go to the Views page;
4. The author displayed for "test post 100" is "Test Author".

**Expected behavior:** <!-- What should happen -->

See above.