### PR TITLE
fix: update one home tile label (resolves #454)

### DIFF
--- a/src/page.njk
+++ b/src/page.njk
@@ -25,7 +25,7 @@ permalink: "/{{ '/' if pageItem.slug === 'home' else pageItem.slug	}}/"
 				<h2>Read current views in inclusive data science</h2>
 			</a>
 			<a href="/learn/" class="green card">
-				<h2>Find inclusive data tools</h2>
+				<h2>Search the We Count Library</h2>
 			</a>
 			<a href="/initiatives/" class="yellow card">
 				<h2>Participate in our inclusion challenge workshops</h2>


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Change the home tile label "find inclusive data tools" to "Search the We Count Library".

## Steps to test

1. Check the home page.

**Expected behavior:** <!-- What should happen -->

The label should have been updated.