### PR TITLE
fix: make initiative tiles links (resolves #456)

### DIFF
--- a/src/_includes/components/workshop.njk
+++ b/src/_includes/components/workshop.njk
@@ -1,16 +1,15 @@
-<div class="one-workshop">
-	<div class="workshop-narrative">
-		<h2 class="h3"><a href="/initiatives/{{ workshop.id }}">{{ workshop.title | safe }}</a></h2>
-		<div class="description">{{ workshop.shortDescription | safe }}</div>
-		{% if workshop.registrationUrl %}
-		<a href={{ workshop.registrationUrl }} class="registration-button">Register here</a>
-		{% endif %}
+<a href="/initiatives/{{ workshop.id }}">
+	<div class="one-workshop">
+		<div class="workshop-narrative">
+			<h2 class="h3">{{ workshop.title | safe }}</h2>
+			<div class="description">{{ workshop.shortDescription | safe }}</div>
+		</div>
+		<div class="workshop-image">
+			{% if workshop.previewImageUrl %}
+				<img src="{{ workshop.previewImageUrl | safe }}" {% if workshop.previewImageAltText %}alt="{{ workshop.previewImageAltText}}"{% else %}role="presentation"{% endif %}>
+			{% else %}
+				<img src="/images/workshop.png" role="presentation">
+			{% endif %}
+		</div>
 	</div>
-	<div class="workshop-image">
-		{% if workshop.previewImageUrl %}
-			<img src="{{ workshop.previewImageUrl | safe }}" {% if workshop.previewImageAltText %}alt="{{ workshop.previewImageAltText}}"{% else %}role="presentation"{% endif %}>
-		{% else %}
-			<img src="/images/workshop.png" role="presentation">
-		{% endif %}
-	</div>
-</div>
+</a>

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -230,9 +230,6 @@
 	// The "post a comment" button on the Workshop page
 	#comment-form button,
 	#comment-form button::before,
-	// The "register here" button on the Intiatives page
-	.registration-button,
-	.registration-button::before,
 	li .pagination-link,
 	li .pagination-link::before,
 	.wp-block-file__button:focus,

--- a/src/scss/components/_initiatives.scss
+++ b/src/scss/components/_initiatives.scss
@@ -1,3 +1,22 @@
+// Workshop page
+.workshop-page {
+	.workshop-cover-image {
+		display: block;
+		margin-left: auto;
+		margin-right: auto;
+		max-width: 100%;
+	}
+
+	.description {
+		margin-bottom: rem(100);
+
+		h3 {
+			border-bottom: rem(5) solid $gold;
+			line-height: rem(60);
+		}
+	}
+}
+
 // Initiatives page: Workshop section
 .workshops {
 	// Every workshop card
@@ -23,6 +42,11 @@
 				border-bottom: rem(2) solid $grey-shade;
 				padding-bottom: rem(16);
 			}
+
+			.description {
+				color: $black;
+				font-weight: $font-weight-normal;
+			}
 		}
 
 		// Workshop images
@@ -38,25 +62,6 @@
 				height: 100%;
 				width: 100%;
 			}
-		}
-	}
-}
-
-// Workshop page
-.workshop-page {
-	.workshop-cover-image {
-		display: block;
-		margin-left: auto;
-		margin-right: auto;
-		max-width: 100%;
-	}
-
-	.description {
-		margin-bottom: rem(100);
-
-		h3 {
-			border-bottom: rem(5) solid $gold;
-			line-height: rem(60);
 		}
 	}
 }
@@ -182,8 +187,7 @@
 }
 
 // Button style shared by the "register here" button on the Intiatives page and the "post a comment" button on the Workshop page
-#comment-form button,
-.registration-button {
+#comment-form button {
 	background-color: $white;
 	border: 0;
 	border-radius: rem(33);
@@ -236,16 +240,6 @@
 	margin: rem(29) 0;
 }
 
-.workshops .registration-button {
-	float: left;
-
-	&:focus,
-	&:hover,
-	&:active {
-		background-color: white;
-	}
-}
-
 @include breakpoint-up(lg) {
 	// Initiatives page: Workshop section
 	.workshops {
@@ -291,9 +285,5 @@
 		&::before {
 			height: rem(54);
 		}
-	}
-
-	.registration-button {
-		padding: rem(8) rem(16);
 	}
 }

--- a/src/utils/data-fetcher-airtable.js
+++ b/src/utils/data-fetcher-airtable.js
@@ -26,7 +26,6 @@ module.exports = {
 					let title = record.get("title");
 					let shortDescription = record.get("short_description");
 					let fullDescription = record.get("full_description");
-					let registrationUrl = record.get("registration_url");
 					let previewImage = record.get("preview_image");
 					let coverImage = record.get("cover_image");
 					let comments = [];
@@ -61,7 +60,6 @@ module.exports = {
 						date: record.get("date"),
 						shortDescription: shortDescription ? md.render(shortDescription) : undefined,
 						fullDescription: fullDescription ? md.render(fullDescription) : undefined,
-						registrationUrl,
 						previewImageUrl: previewImage ? previewImage[0].url : undefined,
 						previewImageAltText: record.get("preview_alt_text"),
 						coverImageUrl: coverImage ? coverImage[0].url : undefined,


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Make each tile on the Initiatives a link to the tile event full description page. Titles on the tiles are no longer links.

## Steps to test

1. Check Airtable "WeCount_dev" base;
2. The "registration_url" field should have been removed;
3. Go to the Initiatives page;
4. Each tile is a link to the tile event full description page;
5. Titles on the tiles are no longer links.

**Expected behavior:** <!-- What should happen -->

See above.