### PR TITLE
fix: remove preview images from the mobile view of the Initiatives page (resolves #458)

### DIFF
--- a/src/scss/components/_initiatives.scss
+++ b/src/scss/components/_initiatives.scss
@@ -24,7 +24,6 @@
 		border-radius: rem(18);
 		box-shadow: rem(0) rem(0) rem(7) rgba(0, 0, 0, 0.25);
 		display: grid;
-		grid-template-rows: auto rem(227);
 		margin: rem(32) 0 rem(32) 0;
 
 		&:hover {
@@ -33,8 +32,7 @@
 
 		// Workshop title and descriptions
 		.workshop-narrative {
-			border-radius: rem(18) rem(18) 0 0;
-			min-height: rem(350);
+			border-radius: rem(18) rem(18) rem(18) rem(18);
 			padding: 0 rem(16) rem(16) rem(16);
 
 			// Workshop titles
@@ -51,17 +49,7 @@
 
 		// Workshop images
 		.workshop-image {
-			// In order to apply border-radius, all inner elements need to have the same border-radius applied.
-			// This includes the wrapper div.workshop-image and inner img element.
-
-			border-radius: 0 0 rem(18) rem(18);
-			height: 100%;
-
-			img {
-				border-radius: 0 0 rem(18) rem(18);
-				height: 100%;
-				width: 100%;
-			}
+			display: none;
 		}
 	}
 }
@@ -256,10 +244,14 @@
 			// In order to apply border-radius, all inner elements need to have the same border-radius applied.
 			// This includes the wrapper div.workshop-image and inner img element.
 			.workshop-image {
-				border-radius: 0 rem(18) rem(18) 0;
+				border-radius: 0 0 rem(18) rem(18);
+				display: block;
+				height: 100%;
 
 				img {
-					border-radius: 0 rem(18) rem(18) 0;
+					border-radius: 0 0 rem(18) rem(18);
+					height: 100%;
+					width: 100%;
 				}
 			}
 		}

--- a/src/scss/components/_initiatives.scss
+++ b/src/scss/components/_initiatives.scss
@@ -33,6 +33,7 @@
 		// Workshop title and descriptions
 		.workshop-narrative {
 			border-radius: rem(18) rem(18) rem(18) rem(18);
+			min-height: rem(208);
 			padding: 0 rem(16) rem(16) rem(16);
 
 			// Workshop titles


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Remove preview images from the mobile view of the Initiatives page based on the modified design at [the figma](https://www.figma.com/file/0lcLol3X5MmOXackT2YbHJ/WeCount-website?node-id=1881%3A3695).

## Steps to test

1. Go to the Initiatives page;
2. On the desktop view, workshop preview images are displayed according to the design;
3. Switch the page to the mobile view, preview images are no longer displayed.
4. The behavior should match what's on [the figma design](https://www.figma.com/file/0lcLol3X5MmOXackT2YbHJ/WeCount-website?node-id=1881%3A3695).

**Expected behavior:** <!-- What should happen -->

See above.