### PR TITLE
feat: allow editing news/views intro texts via WordPress (resolves #464)

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -15,15 +15,30 @@ const markdownFilter = require("./src/filters/markdown.js");
 const w3DateFilter = require("./src/filters/w3-date.js");
 const randomizeFilter = require("./src/filters/randomize.js");
 
+// Slugs for pages that should be excluded as public pages from the WeCount website.
+const privatePageSlugs = ["views", "news"];
+
 require("./src/js/utils.js");
 
 module.exports = function(eleventyConfig) {
 	// Use .eleventyignore instead of .gitignore.
 	eleventyConfig.setUseGitIgnore(false);
 
-	// Add custom collections.
-	eleventyConfig.addCollection("pages", async function() {
+	// "allPages" contains both public pages and pages that define partial contents such as intro paragraphs
+	// in the News and Views pages.
+	eleventyConfig.addCollection("allPages", async function() {
 		return dataFetcherWp.sitePages();
+	});
+
+	// "publicPages" only contains public pages that are accessible via WeCount website URLs.
+	eleventyConfig.addCollection("publicPages", async function() {
+		const publicPagesPromise = dataFetcherWp.sitePages();
+		return new Promise((resolve) => {
+			publicPagesPromise.then(pages => {
+				const results = pages.filter(page => !privatePageSlugs.includes(page.slug));
+				resolve(results);
+			});
+		});
 	});
 
 	eleventyConfig.addCollection("workshops", async function() {

--- a/src/_includes/components/footer-nav.njk
+++ b/src/_includes/components/footer-nav.njk
@@ -1,6 +1,6 @@
 <nav aria-label="Footer" class="footer-nav" style="display: none;">
     <ul>
-        {%- for pageItem in collections.pages %}
+        {%- for pageItem in collections.publicPages %}
             {%- if pageItem.menu_order > 0 %}
                 <li><a {% if page.url === '/' + pageItem.slug + '/' %}aria-current="page" {% endif %}href="/{{ pageItem.slug }}/">{{ pageItem.title }}</a></li>
             {%- endif %}

--- a/src/_includes/components/nav-menu.njk
+++ b/src/_includes/components/nav-menu.njk
@@ -1,5 +1,5 @@
 <nav class="primary-nav" aria-label="Primary Navigation">
-  {%- for pageItem in collections.pages %}
+  {%- for pageItem in collections.publicPages %}
     {%- if pageItem.menu_order > 0 %}
     <a {% if page.url === '/' + pageItem.slug + '/' %}aria-current="page" {% endif %}href="/{{ pageItem.slug }}/">{{ pageItem.title }}</a>
     {%- endif %}

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -147,7 +147,7 @@ processDisplayResults = function (inArray) {
  * @param {Array<Object>} posts - An array of posts to find unique tags. Each object in this array contains a field named "tags"
  * that in a format of:
  * tags: [{slug: {String}, name: {String}}, ...]
- * @return An array of tag slugs to
+ * @return An array of unique tag slugs.
  */
 // eslint-disable-next-line
 getUniqueTags = function (posts) {
@@ -159,6 +159,30 @@ getUniqueTags = function (posts) {
 		}));
 	});
 	return tags;
+};
+
+/*
+ * Extract the page title and intro paragraphs from the data collection for pages.
+ * @param {Array<Object>} allPages - data.collections.allPages
+ * @param {String} pageSlug - The slug of the page to extract the info for.
+ * @return An object containing the page title and intro.
+ */
+// eslint-disable-next-line
+extractPageIntro = function (allPages, pageSlug) {
+	let rtn = {
+		title: null,
+		content: null
+	};
+	for (const page of allPages) {
+		if (page.slug === pageSlug) {
+			rtn = {
+				title: page.title,
+				content: page.content
+			};
+			break;
+		}
+	}
+	return rtn;
 };
 
 /*

--- a/src/news.11tydata.js
+++ b/src/news.11tydata.js
@@ -1,0 +1,11 @@
+/* global extractPageIntro */
+
+require("./js/utils.js");
+
+module.exports = {
+	eleventyComputed: {
+		intro: (data) => {
+			return extractPageIntro(data.collections.allPages, "news");
+		}
+	}
+};

--- a/src/news.njk
+++ b/src/news.njk
@@ -9,7 +9,8 @@ pagination:
 
 {% block content %}
 	<article class="news">
-		<h1>News</h1>
+        <h1>{{ intro.title }}</h1>
+        {{ intro.content | safe }}
 		<div class="news-grid">
 			{% for item in pagination.items %}
 			<div class="api-content">

--- a/src/page.njk
+++ b/src/page.njk
@@ -1,6 +1,6 @@
 ---
 pagination:
-  data: collections.pages
+  data: collections.publicPages
   size: 1
   alias: pageItem
 permalink: "/{{ '/' if pageItem.slug === 'home' else pageItem.slug	}}/"

--- a/src/searchIndex.njk
+++ b/src/searchIndex.njk
@@ -8,7 +8,7 @@ permalink: index.json
 {%- for item in collections.news %}
 	{{ item | dump | safe }},
 {%- endfor %}
-{%- for item in collections.pages %}
+{%- for item in collections.allPages %}
 	{{ item | dump | safe }}{% if not loop.last %},{% endif %}
 {%- endfor %}
 ]

--- a/src/views.11tydata.js
+++ b/src/views.11tydata.js
@@ -1,4 +1,4 @@
-/* global getUniqueTags */
+/* global getUniqueTags, extractPageIntro */
 
 require("./js/utils.js");
 
@@ -6,6 +6,9 @@ module.exports = {
 	eleventyComputed: {
 		tagsOfViews: (data) => {
 			return getUniqueTags(data.collections.views);
+		},
+		intro: (data) => {
+			return extractPageIntro(data.collections.allPages, "views");
 		}
 	}
 };

--- a/src/views.njk
+++ b/src/views.njk
@@ -27,8 +27,8 @@ pagination:
 	</svg>
 
 	<article class="views static-view">
-		<h1>Views</h1>
-
+		<h1>{{ intro.title }}</h1>
+        {{ intro.content | safe }}
 		<form method="get" action="/views/">
 			{% set placeholderForSearch = "Search views..." %}
 			{% set ariaLabelForSearch = "Enter keywords for a search in posts" %}
@@ -59,7 +59,8 @@ pagination:
 
 	{# For displaying dynamic search and filtering results #}
 	<article class="views dynamic-view">
-		<h1>Views</h1>
+        <h1>{{ intro.title }}</h1>
+        {{ intro.content | safe }}
 
 		<form method="get" action="/views/">
 			{# Search #}


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Allow editing News and Views intro texts via WordPress.

## Steps to test

1. Go to News or Views page;
2. Check the intro texts defined in WordPress under "News" and "Views" pages;

**Expected behavior:** <!-- What should happen -->

The intro texts displayed at the top of the News or Views page should match the corresponding in the WordPress.