### PR TITLE
feat: add Netlify Identity script to home page to allow registration

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -33,6 +33,9 @@
 			{% include 'components/footer.njk' %}
 		</div>
 		{% block footerScripts %}{% endblock %}
+		{% if page.url === "/" %}
+		<script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+		{% endif %}
 		<script src="/js/uio.js" defer></script>
 	</body>
 </html>


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This PR adds Netlify's [Identity](https://docs.netlify.com/visitor-access/identity/) services script to the home page, which will allow invited users to set or reset their account passwords.

## Steps to test

1. Load the home page.

**Expected behavior:** See that the Netlify Identity script is loaded in the footer.

## Additional information

Not applicable.

## Related issues

Not applicable.