### PR TITLE
fix: handle image previews for unpublished uploads (fix #472)

### DIFF
--- a/src/admin/cms.js
+++ b/src/admin/cms.js
@@ -18,7 +18,7 @@ env.addFilter("slug", slugFilter);
 env.addFilter("w3DateFilter", w3DateFilter);
 
 const Preview = ({ entry, path, context }) => {
-	const data = context(entry.get("data").toJS());
+	const data = context(entry.get("data").toJS(), entry);
 	const html = env.render(path, data);
 	return <div dangerouslySetInnerHTML={{ __html: html }}/>;
 };
@@ -32,27 +32,29 @@ Preview.propTypes = {
 CMS.registerWidget("uuid", UuidControl, UuidPreview);
 CMS.registerPreviewStyle("/css/main.css");
 
-const Initative = ({ entry }) => (
-	<Preview
+const Initative = ({ entry, getAsset }) => {
+	console.log();
+	return <Preview
 		entry={entry}
 		path="layouts/initiative.njk"
-		context={({ title, id, eventDate, shortDescription, previewImageUrl, previewImageAltText, coverImageUrl, coverImageAltText, body }) => ({
+		context={({title, id, eventDate, shortDescription, previewImageAltText, coverImageAltText, body }, entry) => ({
 			previewMode: true,
 			title,
 			id,
 			eventDate,
 			shortDescription,
-			previewImageUrl,
+			previewImageUrl: getAsset(entry.getIn(["data", "previewImageUrl"])),
 			previewImageAltText,
-			coverImageUrl,
+			coverImageUrl: getAsset(entry.getIn(["data", "coverImageUrl"])),
 			coverImageAltText,
 			content: markdownFilter(body || ""),
 		})}
-	/>
-);
+	/>;
+};
 
 Initative.propTypes = {
-	entry: PropTypes.object.isRequired
+	entry: PropTypes.object.isRequired,
+	getAsset: PropTypes.object.isRequired
 };
 
 CMS.registerPreviewTemplate("initiatives", Initative);

--- a/src/admin/cms.js
+++ b/src/admin/cms.js
@@ -33,7 +33,6 @@ CMS.registerWidget("uuid", UuidControl, UuidPreview);
 CMS.registerPreviewStyle("/css/main.css");
 
 const Initative = ({ entry, getAsset }) => {
-	console.log();
 	return <Preview
 		entry={entry}
 		path="layouts/initiative.njk"


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Ensures that uploaded images are always previewed properly.

## Steps to test

1. Run `npm start`.
2. From the CMS, create a new initiative and upload a cover image.

**Expected behavior:** The image should appear in the preview.

## Additional information

Uses `getAsset()`: https://www.netlifycms.org/docs/customization/#registerpreviewtemplate

## Related issues

Resolves #472.