### PR TITLE
feat: remove link to administration when user logs out

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -42,9 +42,16 @@
       if (user.app_metadata.roles.includes("admin")) {
         const el = document.querySelector("[data-netlify-identity-button]");
         const newEl = document.createElement("p");
+        newEl.id = "administration";
         newEl.className = "has-text-align-center";
         newEl.innerHTML = "<a href='/admin/'>Administration</a>";
         el.parentNode.insertBefore(newEl, el);
+      }
+    });
+    netlifyIdentity.on("logout", () => {
+      const el = document.querySelector("#administration");
+      if (el) {
+        el.remove();
       }
     });
     </script>


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Currently, when a user logs in on the home page and they have the appropriate role, a link to the CMS is appended to the home page footer. If the user logs out the link persists in the DOM. This PR removes the link when a user logs out to avoid possible confusion.

## Steps to test

1. Log in from the home page.
2. Log out again.

**Expected behavior:** The administration link appears upon login and disappears upon logout.

## Additional information

Not applicable.

## Related issues

Not applicable.
