### PR TITLE
fix: fix the broken preview panel when creating a new Views entry (resolves #576)

### DIFF
--- a/src/admin/cms.js
+++ b/src/admin/cms.js
@@ -85,8 +85,10 @@ const Views = createClass({
 
 		const tags = [];
 
-		for (const [index, value] of tagItems.entries()) {
-			tags.push(<a key={index} href={"/tags/" + slugFilter(value)}>{value}</a>);
+		if (tagItems) {
+			for (const [index, value] of tagItems.entries()) {
+				tags.push(<a key={index} href={"/tags/" + slugFilter(value)}>{value}</a>);
+			}
 		}
 
 		return <main>
@@ -303,4 +305,3 @@ CMS.registerEditorComponent({
 		}
 	],
 });
-


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Fix the broken preview panel when creating a new Views entry.

## Steps to test

1. Login and go to Netlify CMS admin page;
2. Select "Views" collection, click "New Views Entry" button;

**Expected behavior:** <!-- What should happen -->
The preview panel at the right should display a proper preview panel instead of reporting the type error.