### PR TITLE
fix: adjust style for displaying a disclaimer

### DIFF
--- a/src/scss/components/_map.scss
+++ b/src/scss/components/_map.scss
@@ -1,5 +1,11 @@
 // The specificity of #defaultContainer.map is required to override the use of #defaultContainer in other css files
 #defaultContainer.map {
+	main {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+	}
+
 	// Hide the footer when the map is in the mobile view
 	footer {
 		display: none;
@@ -35,6 +41,10 @@
 		}
 
 		.content-wrapper {
+			#fl-mapviz-disclaimer {
+				margin-top: -2px;
+			}
+
 			.fl-mapviz-search-results,
 			.fl-mapviz-filter-panel,
 			.fl-mapviz-city-list {


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Adjust the style when displaying a disclaimer.

## Steps to test

1. Check the map and disclaimer on desktop and mobile views.

**Expected behavior:** <!-- What should happen -->

The map and disclaimer should look ok and work ok.