### PR TITLE
fix: correct typo in resource detail template

### DIFF
--- a/src/_includes/layouts/resourceDetail.njk
+++ b/src/_includes/layouts/resourceDetail.njk
@@ -57,7 +57,7 @@
           <div><span class="feature-name">Source:</span> {{ source | replace("<", "&lt;") | safe }}</div>
 
           <svg><use xlink:href="#readability-on-detail" /></svg>
-          <div><span class="feature-name">Redability:</span>
+          <div><span class="feature-name">Readability:</span>
               {% if readability.length > 0 %}{{ readability | join(", ") | safe }}{% else %}N/A{% endif %}
            </div>
 


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This pull request fixes a typo in the resources detail pages.

## Steps to test

1. Go to the Resources page
2. Click on any resource tile

**Expected behavior:** The "Readability" field should say "Readability" and not "Redability"