### PR TITLE
feat: add ISRC project indicator banner to the header (resolves #932, 934)

### DIFF
--- a/src/_includes/components/header.njk
+++ b/src/_includes/components/header.njk
@@ -27,6 +27,7 @@
       </div>
   </div>
   <!-- END markup for Preference Editor -->
+  {% include 'components/idrc-indicator.njk' %}
   {% include 'components/brand.njk' %}
     <div class="site-nav-wrapper">
         <div class="site-nav">

--- a/src/_includes/components/idrc-indicator.njk
+++ b/src/_includes/components/idrc-indicator.njk
@@ -1,0 +1,5 @@
+<div class="idrc-indicator">
+    <div class="idrc-indicator-element">
+        <span>An <a href="https://idrc.ocadu.ca/">Inclusive Design Research Centre</a> project</span>
+    </div>
+</div>

--- a/src/_includes/components/idrc-indicator.njk
+++ b/src/_includes/components/idrc-indicator.njk
@@ -1,5 +1,7 @@
-<div class="idrc-indicator">
-    <div class="idrc-indicator-element">
-        <span>An <a href="https://idrc.ocadu.ca/">Inclusive Design Research Centre</a> project</span>
+<div class="idrc-indicator-wrapper">
+    <div class="idrc-indicator">
+        <div class="idrc-indicator-element">
+            <span>An <a href="https://idrc.ocadu.ca/">Inclusive Design Research Centre</a> project</span>
+        </div>
     </div>
 </div>

--- a/src/scss/components/_brand.scss
+++ b/src/scss/components/_brand.scss
@@ -25,6 +25,8 @@
 
 @include breakpoint-up(lg) {
 	.brand {
+		margin-top: rem(16);
+
 		a {
 			display: inline-flex;
 		}

--- a/src/scss/components/_components.scss
+++ b/src/scss/components/_components.scss
@@ -6,6 +6,7 @@
 @import "expander";
 @import "filter";
 @import "identity";
+@import "idrc-indicator";
 @import "initiatives";
 @import "map";
 @import "news-and-views";

--- a/src/scss/components/_idrc-indicator.scss
+++ b/src/scss/components/_idrc-indicator.scss
@@ -1,0 +1,22 @@
+.idrc-indicator {
+	background-color: #ffcb70;
+
+	.idrc-indicator-element {
+		align-items: center;
+		display: flex;
+		font-family: Roboto, sans-serif;
+		font-size: rem(12);
+		height: rem(55);
+		justify-content: center;
+		max-height: rem(80);
+		max-width: $max-width-margins;
+	}
+}
+
+@include breakpoint-up(lg) {
+	.idrc-indicator .idrc-indicator-element {
+		display: block;
+		margin: auto;
+		padding: rem(18) 0 rem(18) rem(18);
+	}
+}

--- a/src/scss/components/_idrc-indicator.scss
+++ b/src/scss/components/_idrc-indicator.scss
@@ -1,22 +1,18 @@
-.idrc-indicator {
-	background-color: #ffcb70;
+.idrc-indicator-wrapper {
+	background-color: $orange-focus;
+	font-family: Roboto, sans-serif;
 
-	.idrc-indicator-element {
-		align-items: center;
-		display: flex;
-		font-family: Roboto, sans-serif;
-		font-size: rem(12);
-		height: rem(55);
-		justify-content: center;
-		max-height: rem(80);
-		max-width: $max-width-margins;
-	}
-}
-
-@include breakpoint-up(lg) {
-	.idrc-indicator .idrc-indicator-element {
-		display: block;
+	.idrc-indicator {
 		margin: auto;
-		padding: rem(18) 0 rem(18) rem(18);
+		max-width: $max-width-margins;
+
+		.idrc-indicator-element {
+			align-items: center;
+			display: flex;
+			font-size: rem(14);
+			height: rem(55);
+			max-height: rem(80);
+			padding: 0 rem(26);
+		}
 	}
 }

--- a/src/scss/layout/_header.scss
+++ b/src/scss/layout/_header.scss
@@ -159,7 +159,7 @@ header {
 					display: flex;
 					flex: 1;
 					flex-direction: row;
-					justify-content: space-around;
+					justify-content: space-between;
 					position: inherit;
 					top: rem(120);
 					width: auto;
@@ -168,14 +168,16 @@ header {
 					a {
 						border-bottom: none;
 						float: none;
-						margin: rem(24) rem(8);
+						margin: rem(24) rem(8) rem(24) 0;
 						padding: rem(8) rem(10);
 					}
 
 					// When the user is in a section (other than the Home page), underline this particular item
 					// in the top level navigation.
 					a[aria-current="page"] {
-						border-bottom: rem(2) solid $white;
+						background-color: $orange-focus;
+						font-weight: $font-weight-bold;
+						text-decoration: underline;
 					}
 				}
 			}


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run start` and reviewing affected routes
* [X] This pull request has been built by running `npm run build` without errors
* [X] This isn't a duplicate of an existing pull request

## Description

Add the IDRC project indicator banner to the header.

Resolves https://github.com/inclusive-design/wecount.inclusivedesign.ca/issues/932.

## Steps to test

1. Open any page;
2. The IDRC project indicator banner should shown on the header and match [the design](https://www.figma.com/file/0lcLol3X5MmOXackT2YbHJ/WeCount-website?node-id=4016%3A10803).