### PR TITLE
feat: move from sanitize to modern-css-reset (resolves #939)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5899,6 +5899,11 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
+    "modern-css-reset": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/modern-css-reset/-/modern-css-reset-1.4.0.tgz",
+      "integrity": "sha512-0crZmSFmrxkI7159rvQWjpDhy0u4+Awg/iOycJdlVn0RSeft/a+6BrQHR3IqvmdK25sqt0o6Z5Ap7cWgUee2rw=="
+    },
     "moo": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
@@ -7924,11 +7929,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "sanitize.css": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-12.0.1.tgz",
-      "integrity": "sha512-QbusSBnWHaRBZeTxsJyknwI0q+q6m1NtLBmB76JfW/rdVN7Ws6Zz70w65+430/ouVcdNVT3qwrDgrM6PaYyRtw=="
     },
     "sass": {
       "version": "1.32.8",

--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
     "html-minifier": "^4.0.0",
     "infusion": "^3.0.0-dev.20210421T131019Z.2d15978fb.FLUID-6580",
     "markdown-it": "^12.0.4",
+    "modern-css-reset": "^1.4.0",
     "netlify-cms-widget-uuid-v4": "^1.0.12",
     "nodemailer": "^6.4.18",
     "nunjucks": "^3.2.3",
-    "sanitize.css": "^12.0.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/src/scss/abstracts/_reset.scss
+++ b/src/scss/abstracts/_reset.scss
@@ -1,3 +1,3 @@
 /* See https://sass-lang.com/documentation/at-rules/import#importing-css */
 
-@import '../../../node_modules/modern-css-reset/dist/reset.min.css';
+@import '../../../node_modules/modern-css-reset/dist/reset';

--- a/src/scss/abstracts/_reset.scss
+++ b/src/scss/abstracts/_reset.scss
@@ -1,3 +1,3 @@
 /* See https://sass-lang.com/documentation/at-rules/import#importing-css */
 
-@import '../../../node_modules/sanitize.css/sanitize';
+@import '../../../node_modules/modern-css-reset/dist/reset.min.css';

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -49,6 +49,10 @@ a:focus {
 	outline: none;
 }
 
+p {
+	margin: 1em 0;
+}
+
 .wp-block-file__button:hover::before,
 .wp-block-file__button:focus::before,
 .wp-block-file__button:active::before,

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -25,6 +25,7 @@ h3,
 .h3 {
 	font-size: rem(18);
 	font-weight: $font-weight-bold;
+	margin: 1em 0;
 }
 
 h4 {
@@ -47,6 +48,10 @@ a:focus {
 
 a:focus {
 	outline: none;
+}
+
+li {
+	list-style: none;
 }
 
 p {

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -7,6 +7,18 @@
 	font-family: $family-sans-serif;
 }
 
+input,
+button,
+textarea,
+select {
+	line-height: normal;
+}
+
+::-webkit-input-placeholder {
+	color: inherit;
+	opacity: 0.54;
+}
+
 h1 {
 	color: $grey-dark;
 	font-size: rem(35);

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -11,12 +11,14 @@ h1 {
 	color: $grey-dark;
 	font-size: rem(35);
 	font-weight: $font-weight-semibold;
+	margin: 0.67em 0;
 }
 
 h2 {
 	color: $grey-dark;
 	font-size: rem(24);
 	font-weight: $font-weight-medium;
+	margin: 0.83em 0;
 }
 
 h3,
@@ -55,6 +57,11 @@ button:focus::before,
 button:active::before {
 	left: rem(4);
 	top: rem(4);
+}
+
+// SVG fill rule imported from sanitize ensures SVG colour agrees with text colour
+svg:not([fill]) {
+	fill: currentColor;
 }
 
 .wp-block-file__button::-moz-focus-inner,

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -85,6 +85,11 @@ svg:not([fill]) {
 	fill: currentColor;
 }
 
+button {
+	align-items: center;
+	display: flex;
+}
+
 .wp-block-file__button::-moz-focus-inner,
 button::-moz-focus-inner {
 	outline: none;

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -85,11 +85,6 @@ svg:not([fill]) {
 	fill: currentColor;
 }
 
-button {
-	align-items: center;
-	display: flex;
-}
-
 .wp-block-file__button::-moz-focus-inner,
 button::-moz-focus-inner {
 	outline: none;

--- a/src/scss/components/_filter.scss
+++ b/src/scss/components/_filter.scss
@@ -135,7 +135,7 @@
 
 	.apply-button,
 	.reset-button {
-		@extend .has-centred-children;
+		@extend %has-vertically-centered-children;
 
 		padding: rem(1) rem(3);
 

--- a/src/scss/components/_filter.scss
+++ b/src/scss/components/_filter.scss
@@ -135,6 +135,8 @@
 
 	.apply-button,
 	.reset-button {
+		@extend .has-centred-children;
+
 		padding: rem(1) rem(3);
 
 		span {

--- a/src/scss/components/_pagination.scss
+++ b/src/scss/components/_pagination.scss
@@ -87,6 +87,7 @@
 
 	li:first-child,
 	li:last-child {
+		display: flex;
 		flex: 1;
 	}
 

--- a/src/scss/components/_pagination.scss
+++ b/src/scss/components/_pagination.scss
@@ -87,7 +87,6 @@
 
 	li:first-child,
 	li:last-child {
-		display: flex;
 		flex: 1;
 	}
 
@@ -170,7 +169,7 @@
 
 		.pagination-next,
 		.pagination-previous {
-			line-height: rem(40);
+			line-height: rem(48);
 		}
 	}
 }

--- a/src/scss/components/_resources.scss
+++ b/src/scss/components/_resources.scss
@@ -83,10 +83,8 @@
 			margin-top: rem(24);
 
 			button {
-				align-items: center;
 				background-color: $white;
 				box-shadow: 0 0 rem(7) $border-shadow-colour;
-				display: flex;
 			}
 		}
 

--- a/src/scss/components/_resources.scss
+++ b/src/scss/components/_resources.scss
@@ -83,6 +83,8 @@
 			margin-top: rem(24);
 
 			button {
+				@extend .has-centred-children;
+
 				background-color: $white;
 				box-shadow: 0 0 rem(7) $border-shadow-colour;
 			}

--- a/src/scss/components/_resources.scss
+++ b/src/scss/components/_resources.scss
@@ -99,6 +99,8 @@
 			}
 
 			button {
+				@extend .has-centred-children;
+
 				align-self: center;
 				height: rem(32);
 				margin-right: 0;
@@ -130,6 +132,8 @@
 		}
 
 		.filter-expand-button {
+			@extend .has-centred-children;
+
 			--expand-button-color: none;
 			--expand-button-stroke-color: #{$grey-dark};
 

--- a/src/scss/components/_resources.scss
+++ b/src/scss/components/_resources.scss
@@ -83,8 +83,10 @@
 			margin-top: rem(24);
 
 			button {
+				align-items: center;
 				background-color: $white;
 				box-shadow: 0 0 rem(7) $border-shadow-colour;
+				display: flex;
 			}
 		}
 

--- a/src/scss/components/_resources.scss
+++ b/src/scss/components/_resources.scss
@@ -83,7 +83,7 @@
 			margin-top: rem(24);
 
 			button {
-				@extend .has-centred-children;
+				@extend %has-vertically-centered-children;
 
 				background-color: $white;
 				box-shadow: 0 0 rem(7) $border-shadow-colour;
@@ -101,7 +101,7 @@
 			}
 
 			button {
-				@extend .has-centred-children;
+				@extend %has-vertically-centered-children;
 
 				align-self: center;
 				height: rem(32);
@@ -134,7 +134,7 @@
 		}
 
 		.filter-expand-button {
-			@extend .has-centred-children;
+			@extend %has-vertically-centered-children;
 
 			--expand-button-color: none;
 			--expand-button-stroke-color: #{$grey-dark};

--- a/src/scss/layout/_layout.scss
+++ b/src/scss/layout/_layout.scss
@@ -38,6 +38,12 @@ article {
 	}
 }
 
+// style for centering children of some buttons (#939)
+.has-centred-children {
+	align-items: center;
+	display: flex;
+}
+
 // WP customized styles
 .has-small-font-size {
 	font-size: 84%;

--- a/src/scss/layout/_layout.scss
+++ b/src/scss/layout/_layout.scss
@@ -39,7 +39,7 @@ article {
 }
 
 // style for centering children of some buttons (#939)
-.has-centred-children {
+%has-vertically-centered-children {
 	align-items: center;
 	display: flex;
 }


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [ ] This pull request has been tested by running `npm run start` and reviewing affected routes
* [ ] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Migrate from CSS normalisation library sanitize.css to "modern CSS reset"

**Expected behavior:**

Hovering over any text element should show the standard "caret" cursor indicating selectable text

## Related issues

Resolves #939
