### PR TITLE
fix: restore bullet styling which was lost in transition to modern-css-reset

### DIFF
--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -63,7 +63,7 @@ a:focus {
 }
 
 li {
-	list-style: none;
+	list-style: unset;
 }
 
 p {

--- a/src/scss/components/_pagination.scss
+++ b/src/scss/components/_pagination.scss
@@ -1,7 +1,6 @@
 .pagination {
 	display: block;
 	line-height: rem(38);
-	list-style: none;
 	margin-left: -10%;
 	margin-right: -10%;
 	margin-top: rem(27);
@@ -71,6 +70,8 @@
 	}
 
 	li {
+		list-style: none;
+
 		a.is-current {
 			background-color: $green-pale;
 			box-shadow: 0 0 0 rem(2) $green-dark inset;


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [ ] This pull request has been tested by running `npm run start` and reviewing affected routes
* [ ] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

As part of our transition to modern-css-reset in https://github.com/inclusive-design/wecount.inclusivedesign.ca/pull/940 we lost a few styling rules from our reset, including those which applied default HTML list styling. As a result, unordered lists in markdown appear without any styling as shown in the following screenshot

![wecount-bullets](https://user-images.githubusercontent.com/561418/175955531-9d7a8caa-7bc7-4eda-bfb3-e38eb6baabbe.png)

## Steps to test

View a page with a bulleted list such as https://wecount.inclusivedesign.ca/views/pluralistic-data-infrastructure/

**Expected behavior:**

List should appear styled as a default HTML unordered list

