### PR TITLE
fix: remove sharepoint field from resources

### DIFF
--- a/src/_includes/layouts/resourceDetail.njk
+++ b/src/_includes/layouts/resourceDetail.njk
@@ -75,13 +75,6 @@
           </div>
           {% endif %}
 
-          {% if sharePointUrl %}
-          <svg><use xlink:href="#share-point-url" /></svg>
-          <div><span class="feature-name">SharePoint URL:</span>
-              <a href="{{ sharePointUrl }}">{{ sharePointUrl | safe }}</a>
-          </div>
-          {% endif %}
-
           <svg><use xlink:href="#keywords" /></svg>
           <div><span class="feature-name">Keywords:</span>
               {% if keywords.length > 0 %}{{ keywords | join(", ") | safe }}{% else %}N/A{% endif %}

--- a/src/admin/cms.js
+++ b/src/admin/cms.js
@@ -145,7 +145,7 @@ const Resources = ({ entry }) => {
 	return <NunjucksPreview
 		entry={entry}
 		path="layouts/resourceDetail.njk"
-		context={({title, focus, source, readability, type, openSource, link, sharePointUrl, keywords, learnTags, summary, body }) => ({
+		context={({title, focus, source, readability, type, openSource, link, keywords, learnTags, summary, body }) => ({
 			previewMode: true,
 			title,
 			focus,
@@ -154,7 +154,6 @@ const Resources = ({ entry }) => {
 			type,
 			openSource,
 			link,
-			sharePointUrl,
 			keywords,
 			learnTags,
 			summary,

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -205,10 +205,6 @@ collections:
         widget: boolean
         default: false
         required: false
-      - label: SharePoint URL
-        name: sharePointUrl
-        widget: string
-        required: false
       - label: External Link
         name: link
         widget: string

--- a/src/collections/resources/2020-state-of-data-science-pdf-article.md
+++ b/src/collections/resources/2020-state-of-data-science-pdf-article.md
@@ -5,7 +5,6 @@ source: "Anaconda"
 readability: ["Beginner"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/2020%20State%20of%20Data%20Science.pdf"
 link: "https://www.anaconda.com/state-of-data-science-2020"
 keywords: []
 learnTags: ["business","education","ethics","researchCentre"]

--- a/src/collections/resources/a-decomposition-of-the-outlier-detection-problem-into-a-set-of-supervised-learning-problems-pdf-article.md
+++ b/src/collections/resources/a-decomposition-of-the-outlier-detection-problem-into-a-set-of-supervised-learning-problems-pdf-article.md
@@ -5,7 +5,6 @@ source: "Machine Learning Journal"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/A%20decomposition%20of%20the%20outlier%20detection%20problem%20into%20a%20set%20of%20supervised%20learning%20problems.pdf"
 keywords: ["Outlier detection","Machine learning","Outlier explanations"]
 learnTags: ["dataset","dataTools","solution"]
 summary: "A discussion of the use of an attribute-wise learning for scoring outliers (ALSO) approach to manage outlier data and a comparison of this method to classic methods of outlier detection. "

--- a/src/collections/resources/a-multimodal-feature-learning-approach-for-sentiment-analysis-of-social-network-multimedia-pdf-article.md
+++ b/src/collections/resources/a-multimodal-feature-learning-approach-for-sentiment-analysis-of-social-network-multimedia-pdf-article.md
@@ -5,7 +5,6 @@ source: "MICC "
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/A%20Multimodal%20Feature%20Learning%20Approach%20for%20Sentiment%20Analysis.pdf"
 link: "http://www.micc.unifi.it/wp-content/uploads/2015/12/2015-multimodal-feature-learning.pdf"
 keywords: ["Sentiment analysis","feature learning","micro-blogging","Twitter"]
 learnTags: ["dataset","methods","framework","machineLearning","researchCentre"]

--- a/src/collections/resources/a-peoples-guide-to-ai-pdf-article.md
+++ b/src/collections/resources/a-peoples-guide-to-ai-pdf-article.md
@@ -5,7 +5,6 @@ source: "Allied Media Projects"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/People's%20Guide%20to%20AI.pdf"
 keywords: []
 learnTags: ["basicAI","ethics","fairness","notForProfit"]
 summary: "An introductory guide on AI with information and activities to help readers gain a deeper understanding of AI concepts and problems. "

--- a/src/collections/resources/a-reinforcement-learning-and-iot-based-system-to-assist-patients-with-disabilities-pdf-article.md
+++ b/src/collections/resources/a-reinforcement-learning-and-iot-based-system-to-assist-patients-with-disabilities-pdf-article.md
@@ -5,7 +5,6 @@ source: "AI4EIoTs 2020"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/A%20Reinforcement%20Learning%20and%20IoT%20based%20System%20to%20Assist%20Patients%20with%20Disabilities.pdf"
 keywords: ["Artificial Intelligence","Disability","Healthcare","IoT","Pill Reminder","Reinforcement Learning."]
 learnTags: ["dataTools","methods","disability","solution"]
 summary: "This paper presents an intelligent guidance and monitoring system that can assist elderly persons and patients in their treatment schedule, such as reminding individuals to take their medication through suitable audio, visual and text messages. "

--- a/src/collections/resources/a-survey-on-bias-and-fairness-in-machine-learning-pdf-article.md
+++ b/src/collections/resources/a-survey-on-bias-and-fairness-in-machine-learning-pdf-article.md
@@ -5,7 +5,6 @@ source: "arXiv"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/A%20survey%20on%20bias%20and%20fiarness%20in%20machine%20learning.pdf"
 keywords: ["Fairness and Bias in Artificial Intelligence","Machine Learning","Deep Learning","Natural Language Processing","Representation Learning"]
 learnTags: ["bias","ethics","fairness"]
 summary: "A taxonomy of terms related to fairness and AI bias in machine learning, deep learning, natural language processing and algorithms. "

--- a/src/collections/resources/accessible-computer-science-for-k-12-students-with-disabilities-pdf-article.md
+++ b/src/collections/resources/accessible-computer-science-for-k-12-students-with-disabilities-pdf-article.md
@@ -5,7 +5,6 @@ source: "Auburn University"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Accessible%20Computer%20Science%20for%20K-12%20Students%20with%20Disabilities.pdf?csf=1&web=1&e=RzFFmB"
 keywords: ["Accessibility","K-12 Education","Block-Based Programming"]
 learnTags: ["bias","methods","disability","education","ethics","fairness","framework","inclusivePractice","solution"]
 summary: "A master's thesis that aims to make computer science concepts accessible to K-12 students who are Deaf/Hard of Hearing, Blind/Low Vision and those with motor disabilities.  "

--- a/src/collections/resources/accommodating-workers-with-disabilities-in-the-post-covid-world-pdf-article.md
+++ b/src/collections/resources/accommodating-workers-with-disabilities-in-the-post-covid-world-pdf-article.md
@@ -5,7 +5,6 @@ source: "Journal of Occupational and Environmental Hygiene"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Accommodating%20workers%20with%20disabilities%20in%20the%20post%20Covid%20world.pdf?csf=1&web=1&e=taMqQ9"
 keywords: ["Accessibility","ADA accommodation","assisted technology","Covid-19","disabled workers","Zoom fatigue"]
 learnTags: ["bias","business","methods","disability","ethics","fairness","framework","inclusivePractice"]
 summary: "A paper that highlights technological advances, utilized during the pandemic to facilitate work from home, that can be implemented post-pandemic as part of a strategy to increase accessibility for a range of disabilities.  "

--- a/src/collections/resources/ai-enabled-tools-and-automation-to-improve-accessibility-website-resource.md
+++ b/src/collections/resources/ai-enabled-tools-and-automation-to-improve-accessibility-website-resource.md
@@ -5,7 +5,6 @@ source: "IBM "
 readability: ["Intermediate"]
 type: "Website Resource"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/AI-Enabled%20Tools%20and%20Automation%20to%20Improve%20Accessibility%20Age%20and%20Ability.pdf"
 link: "https://www.ibm.com/able/dynamic-assessment-plug-in.html"
 keywords: []
 learnTags: ["dataTools","disability","inclusivePractice","solution"]

--- a/src/collections/resources/ai-fairness-for-people-with-disabilities-point-of-view-pdf-article.md
+++ b/src/collections/resources/ai-fairness-for-people-with-disabilities-point-of-view-pdf-article.md
@@ -5,7 +5,6 @@ source: "IBM "
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/AI%20%20Fairness%20for%20People%20with%20Disabilities_Point%20of%20View.pdf"
 keywords: []
 learnTags: ["bias","dataset","methods","disability","ethics","fairness","inclusivePractice","smallData"]
 summary: "A discussion of the challenges persons with disabilities face with current AI systems and the approaches that need to be adopted to ensure fairness in AI development. "

--- a/src/collections/resources/ai-for-the-common-good-pitfalls-challenges-and-ethics-pen-testing-pdf-article.md
+++ b/src/collections/resources/ai-for-the-common-good-pitfalls-challenges-and-ethics-pen-testing-pdf-article.md
@@ -5,7 +5,6 @@ source: "Paladyn, Journal of Behavioral Robotics"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/AI%20for%20the%20Common%20Good%20Pitfalls,%20challenges,%20and%20ethics%20pen-testing.pdf"
 keywords: ["artificial intelligence","machine learning","data science","AI ethics","ethics and ethics codes","risks and impacts","Common Good","AI for Social Good"]
 learnTags: ["methods","ethics","fairness"]
 summary: "A critical discussion on the challenges and pitfalls that can occur when determining what the Common Good is and how it can be enhanced by AI. "

--- a/src/collections/resources/ai-gone-mental-engagement-and-ethics-in-data-driven-technology-for-mental-health-pdf-article.md
+++ b/src/collections/resources/ai-gone-mental-engagement-and-ethics-in-data-driven-technology-for-mental-health-pdf-article.md
@@ -5,7 +5,6 @@ source: "Journal of Mental Health"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/AI%20gone%20mental%20engagement%20and%20ethics%20in%20data%20driven%20technology%20for%20mental%20health.pdf"
 link: "https://www.tandfonline.com/doi/pdf/10.1080/09638237.2020.1714011?needAccess=true"
 keywords: []
 learnTags: ["dataset","dataTools","disability","ethics","fairness"]

--- a/src/collections/resources/ai-governance-a-holistic-approach-to-implement-ethics-into-ai-pdf-article.md
+++ b/src/collections/resources/ai-governance-a-holistic-approach-to-implement-ethics-into-ai-pdf-article.md
@@ -5,7 +5,6 @@ source: "World Economic Forum"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/AI%20Governance%20A%20Holistic%20Approach%20to%20Implement%20Ethics%20into%20AI%20(1).pdf"
 keywords: []
 learnTags: ["bias","ethics","fairness","framework","government","trust"]
 summary: "This paper recommends the incorporation of a graded governance model for the implementation of ethical concerns in AI systems, suggesting that good AI governance consists of a balanced policy mix combined with certification systems, technology standards and monetary incentives.  "

--- a/src/collections/resources/ai-in-the-headlines-the-portrayal-of-the-ethical-issues-of-artificial-intelligence-in-the-media-pdf-article.md
+++ b/src/collections/resources/ai-in-the-headlines-the-portrayal-of-the-ethical-issues-of-artificial-intelligence-in-the-media-pdf-article.md
@@ -5,7 +5,6 @@ source: "AI and Society Journal"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/AI%20In%20The%20Headlines-%20The%20Portrayal%20Of%20ethical%20issues%20of%20AI%20in%20the%20media.pdf"
 link: "https://link.springer.com/article/10.1007/s00146-020-00965-5"
 keywords: ["Artificial intelligence (AI)","Ethics","Media","News","Public discourse","Public policy"]
 learnTags: ["bias","ethics","framework","government","solution","trust"]

--- a/src/collections/resources/ai-is-the-future-of-hiring-but-it’s-far-from-immune-to-bias.md
+++ b/src/collections/resources/ai-is-the-future-of-hiring-but-it’s-far-from-immune-to-bias.md
@@ -6,7 +6,6 @@ readability:
   - Beginner
 type: PDF Article
 openSource: true
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount-OptimizingDiversitywithDisabilityODDChannel/Shared%20Documents/Optimizing%20Diversity%20with%20Disability%20(ODD)%20Channel/Hiring%20Systems/Article%20+%20Resources/AI%20is%20the%20future%20of%20hiring,%20but%20it%27s%20far%20from%20immune%20to%20bias.pdf?csf=1&web=1&e=EURMzf
 link: https://scholar.harvard.edu/files/dipayan/files/ai_in_hiring_can_lead_to_algorithmic_bias_-_quartz_at_work.pdf
 learnTags:
   - bias

--- a/src/collections/resources/ai-needs-more-regulation-not-less-website-article.md
+++ b/src/collections/resources/ai-needs-more-regulation-not-less-website-article.md
@@ -5,7 +5,6 @@ source: "Brookings"
 readability: ["Intermediate"]
 type: "Website Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/AI%20needs%20more%20regulation,%20not%20less.pdf"
 link: "https://www.brookings.edu/research/ai-needs-more-regulation-not-less/"
 keywords: []
 learnTags: ["ethics","fairness","framework"]

--- a/src/collections/resources/algorithm-driven-hiring-tools-innovative-recruitment-or-expedited-disability-discrimination-pdf-article.md
+++ b/src/collections/resources/algorithm-driven-hiring-tools-innovative-recruitment-or-expedited-disability-discrimination-pdf-article.md
@@ -5,7 +5,6 @@ source: "Center for Democracy and Technology"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Algorithm-Driven%20Hiring%20Tools.pdf?csf=1&web=1&e=55Ryoq"
 keywords: []
 learnTags: ["bias","business","methods","employment","ethics","fairness"]
 summary: " A report by the Center for Democracy & Technology that highlights how hiring tools may affect people with disabilities, the legal liability employers may face for using such tools, and concrete steps for employers and vendors to mitigate some of the most significant areas of concern. "

--- a/src/collections/resources/algorithmic-accountability-policy-toolkit-pdf-article.md
+++ b/src/collections/resources/algorithmic-accountability-policy-toolkit-pdf-article.md
@@ -5,7 +5,6 @@ source: "AI Now Institute"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Algorithmic%20Accountabiltiy%20Policy%20Toolkit.pdf"
 keywords: []
 learnTags: ["bias","methods","disability","ethics","fairness","government"]
 summary: "Provides a toolkit of resources on the current debates and concerns in AI, algorithms, machine learning and automated decisions from a legal perspective. "

--- a/src/collections/resources/algorithmic-fair-use-pdf-article.md
+++ b/src/collections/resources/algorithmic-fair-use-pdf-article.md
@@ -5,7 +5,6 @@ source: "University of Chicago Law Review"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Algorithmic%20Fair%20Use.pdf"
 keywords: []
 learnTags: ["bias","methods","ethics","fairness","government"]
 summary: "This article discusses the legal challenges that have developed around using algorithms, which are subject to bias decisions and biased data, to detect copyright infringement in a multimedia environment and the subjectiveness in judging \"fair use.\"  "

--- a/src/collections/resources/algorithmic-impact-assessments-a-practical-framework-for-public-agency-accountability-pdf-article.md
+++ b/src/collections/resources/algorithmic-impact-assessments-a-practical-framework-for-public-agency-accountability-pdf-article.md
@@ -5,7 +5,6 @@ source: "AI Now Institute"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Algorthmic%20Impact%20Assessments.pdf"
 link: "https://ainowinstitute.org/aiareport2018.pdf"
 keywords: []
 learnTags: ["bias","business","methods","disability","ethics","fairness","framework","government"]

--- a/src/collections/resources/algorithmic-justice-league-overview-pdf-article.md
+++ b/src/collections/resources/algorithmic-justice-league-overview-pdf-article.md
@@ -5,7 +5,6 @@ source: "Algorithmic Justice League"
 readability: ["Beginner"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/AJL%20Overview.pdf"
 link: "https://www.ajl.org/learn-more"
 keywords: []
 learnTags: ["basicAI","bias","ethics","fairness","notForProfit"]

--- a/src/collections/resources/algorithms-and-the-coronavirus-pandemic-pdf-article.md
+++ b/src/collections/resources/algorithms-and-the-coronavirus-pandemic-pdf-article.md
@@ -5,7 +5,6 @@ source: "Financial Times"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Algorithms%20and%20the%20Coronavirus%20Pandemic.pdf?csf=1&web=1&e=RXXrxe"
 keywords: []
 learnTags: ["bias","ethics","fairness","government","trust"]
 summary: "An article that discusses the increasing public backlash over governments’ use of automated decision making tools. "

--- a/src/collections/resources/all-about-us-indigenous-data-analysis-workshop-capacity-building-in-the-canadian-alliance-for-healthy-hearts-and-minds-first-nations-cohort-pdf-article.md
+++ b/src/collections/resources/all-about-us-indigenous-data-analysis-workshop-capacity-building-in-the-canadian-alliance-for-healthy-hearts-and-minds-first-nations-cohort-pdf-article.md
@@ -5,7 +5,6 @@ source: "Canadian Journal of Cardiology"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/All%20about%20us_Indigenous%20Data%20Analysis%20Workshop.pdf"
 keywords: []
 learnTags: ["basicAI","inclusivePractice"]
 summary: "This article describes a three-day workshop with university researchers and several First Nation communities to increase the capacity for data management and analysis by those communities. "

--- a/src/collections/resources/an-empirical-characterization-of-fair-machine-learning-for-clinical-risk-prediction-pdf-article.md
+++ b/src/collections/resources/an-empirical-characterization-of-fair-machine-learning-for-clinical-risk-prediction-pdf-article.md
@@ -5,7 +5,6 @@ source: " Journal of Biomedical Informatics"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/An%20Empirical%20Characterization%20of%20Fair%20Machine%20Learning%20For%20Clinical%20Risk%20Prediction.pdf?csf=1&web=1&e=Y1fKOs"
 keywords: []
 learnTags: ["bias","ethics","fairness"]
 summary: "A study by researchers from Stanford University concludes that the use of machine learning to guide clinical decision-making has the potential to worsen existing health disparities. "

--- a/src/collections/resources/an-ethics-evaluation-tool-for-automating-ethical-decision-making-in-robots-and-self-driving-cars-pdf-article.md
+++ b/src/collections/resources/an-ethics-evaluation-tool-for-automating-ethical-decision-making-in-robots-and-self-driving-cars-pdf-article.md
@@ -5,7 +5,6 @@ source: "Applied Artificial Intelligence"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/An%20Ethics%20Evaluation%20Tool%20for%20Automating%20Ethical%20Decision%20Making%20in%20Robots%20and%20Self%20Driving%20Cars.pdf"
 keywords: []
 learnTags: ["methods","ethics","fairness"]
 summary: "Just as usability is a part of the design process, this article describes the need to incorporate an ethics evaluation tool in AI that makes ethical and moral decisions.  "

--- a/src/collections/resources/an-inclusive-digital-economy-for-people-with-disabilities-pdf-article.md
+++ b/src/collections/resources/an-inclusive-digital-economy-for-people-with-disabilities-pdf-article.md
@@ -5,7 +5,6 @@ source: "Fundación ONCE and the ILO Global Business and Disability Network"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/An%20Inclusive%20Digital%20Economy%20for%20People%20with%20Disabilities.pdf?csf=1&web=1&e=bP7IOo"
 keywords: []
 learnTags: ["bias","disability","ethics","fairness"]
 summary: "A publication that aims to increase awareness of the impact of a digital world of work on people with disabilities and identify actions needed to shape a future of work in a more disability-inclusive way.  "

--- a/src/collections/resources/an-overview-of-ethical-issues-in-using-ai-systems-in-hiring-with-a-case-study-of-amazon’s-ai-based-hiring-tool.md
+++ b/src/collections/resources/an-overview-of-ethical-issues-in-using-ai-systems-in-hiring-with-a-case-study-of-amazon’s-ai-based-hiring-tool.md
@@ -7,7 +7,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: true
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount-OptimizingDiversitywithDisabilityODDChannel/Shared%20Documents/Optimizing%20Diversity%20with%20Disability%20(ODD)%20Channel/Hiring%20Systems/Article%20+%20Resources/An%20Overview%20of%20Ethical%20Issues%20in%20using%20AI%20systems%20in%20hirig%20with%20a%20Case%20Study%20of%20Amazon%27s%20AI%20based%20hiring%20Tool.pdf?csf=1&web=1&e=QnkcSA
 link: https://www.academia.edu/42965903/An_overview_of_ethical_issues_in_using_AI_systems_in_hiring_with_a_case_study_of_Amazons_AI_based_hiring_tool
 learnTags:
   - business

--- a/src/collections/resources/anatomy-of-a-new-data-science-course-in-privacy-ethics-and-security-pdf-article.md
+++ b/src/collections/resources/anatomy-of-a-new-data-science-course-in-privacy-ethics-and-security-pdf-article.md
@@ -5,7 +5,6 @@ source: "WCCCE 2018"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Anatomy%20of%20a%20New%20Data%20Science%20Course%20in%20Privacy,%20Ethics,%20and%20Security.pdf"
 keywords: ["Computer security","privacy","ethics","data science","information ethics","human dignity","database privacy"]
 learnTags: ["education","ethics","fairness"]
 summary: "A description of a new ethics course created for a Master of Data Science program at UBC, including learning goals, content, activities and evaluation methods.  "

--- a/src/collections/resources/artificial-intelligence-and-disability-too-much-promise-yet-too-little-substance-website-article.md
+++ b/src/collections/resources/artificial-intelligence-and-disability-too-much-promise-yet-too-little-substance-website-article.md
@@ -5,7 +5,6 @@ source: "AI and Ethics"
 readability: ["Intermediate"]
 type: "Website Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Artificial%20intelligence%20and%20disability%20-%20too%20much%20promise,%20yet%20too%20little%20substance.pdf?csf=1&web=1&e=o6RS3p"
 link: "https://link.springer.com/article/10.1007/s43681-020-00004-5"
 keywords: []
 learnTags: ["basicAI","bias","disability","fairness"]

--- a/src/collections/resources/artificial-intelligence-and-human-rights-pdf-article.md
+++ b/src/collections/resources/artificial-intelligence-and-human-rights-pdf-article.md
@@ -5,7 +5,6 @@ source: "Journal of Democracy"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/AI_and_Human_Rights.pdf"
 keywords: ["data analysis","human capital","human resource ethics","hiring and recruitment","information systems","decision-making tools"]
 learnTags: ["business","ethics","fairness","framework","government"]
 summary: "An article that examines the UN Human Rights Framework as a way to address AI concerns. "

--- a/src/collections/resources/artificial-intelligence-fairness-in-the-context-of-accessibility-research-on-intelligent-systems-for-people-who-are-deaf-or-hard-of-hearing-pdf-article.md
+++ b/src/collections/resources/artificial-intelligence-fairness-in-the-context-of-accessibility-research-on-intelligent-systems-for-people-who-are-deaf-or-hard-of-hearing-pdf-article.md
@@ -7,7 +7,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: true
-sharePointUrl: https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Artificial%20Intelligence%20Fairness%20in%20the%20Context%20of%20Accessibility%20Research%20on%20Intelligent%20Systems%20for%20People%20who%20are%20Deaf%20or%20Hard%20of%20Hearing.pdf
 keywords:
   - Artificial intelligence
   - fairness

--- a/src/collections/resources/artificial-intelligence-index-report-2019-pdf-article.md
+++ b/src/collections/resources/artificial-intelligence-index-report-2019-pdf-article.md
@@ -5,7 +5,6 @@ source: "Stanford HAI"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/ai_index_2019_report.pdf"
 link: "https://hai.stanford.edu/sites/g/files/sbiybj10986/f/ai_index_2019_report.pdf"
 keywords: []
 learnTags: ["bias","dataset","dataTools","methods","ethics","fairness","framework","inclusivePractice"]

--- a/src/collections/resources/artificial-intelligence-machine-learning-and-bias-in-finance-toward-responsible-innovation-pdf-article.md
+++ b/src/collections/resources/artificial-intelligence-machine-learning-and-bias-in-finance-toward-responsible-innovation-pdf-article.md
@@ -5,7 +5,6 @@ source: "Fordham Law Review"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Artificial%20intelligence,%20machine%20learning,%20and%20bias%20in%20finance_Toward%20responsible%20innovation.pdf"
 keywords: []
 learnTags: ["bias","business","dataset","ethics","fairness","government","machineLearning"]
 summary: "A financial law article showing the regulation challenges of consumer data algorithms in commerce.   "

--- a/src/collections/resources/automl-zero-evolving-machine-learning-algorithms-from-scratch-pdf-article.md
+++ b/src/collections/resources/automl-zero-evolving-machine-learning-algorithms-from-scratch-pdf-article.md
@@ -5,7 +5,6 @@ source: "ICML 2020"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/AutoML-Zero_Evolving%20Machine%20Learning%20Algorithms%20from%20Scratch.pdf"
 keywords: []
 learnTags: ["bias","methods","machineLearning"]
 summary: "A Google paper discussing AutoML, a new machine learning method to reduce bias by providing small pieces of code to allow the computer to build its own algorithms with less human input. "

--- a/src/collections/resources/back-on-the-data-trail-the-evolution-of-canadas-data-broker-industry-pdf-article.md
+++ b/src/collections/resources/back-on-the-data-trail-the-evolution-of-canadas-data-broker-industry-pdf-article.md
@@ -5,7 +5,6 @@ source: "CIPPIC"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Back%20on%20the%20data%20trail.pdf"
 keywords: []
 learnTags: ["bias","business","dataBroker","dataset","ethics","fairness","government"]
 summary: "A public interest report that provides an easy-to-read overview and breakdown on the data broker industry in Canada, including data types and sources, services offered, and legal regulations. "

--- a/src/collections/resources/better-decision-support-through-exploratory-discrimination-aware-data-mining-foundations-and-empirical-evidence-pdf-article.md
+++ b/src/collections/resources/better-decision-support-through-exploratory-discrimination-aware-data-mining-foundations-and-empirical-evidence-pdf-article.md
@@ -5,7 +5,6 @@ source: "Artificial Intelligence and Law"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Better%20decision%20support%20through%20exploratory%20discrimination%20aware%20data%20mining%20foundations%20and%20empirical%20evidence.pdf"
 keywords: ["Discrimination discovery and prevention","Data mining\nfor decision support","Discrimination-aware data mining","Responsible\ndata mining","Evaluation","User studies","Online experiment"," Mechanical\nTurk"]
 learnTags: ["bias","methods","ethics","fairness"]
 summary: "This paper describes an exploratory study that uses different discrimination-aware data mining (DADM) methods to determine how information technology supports the decision process and keep it free from bias. "

--- a/src/collections/resources/beyond-a-human-rightsbased-approach-to-ai-governance-promise-pitfalls-plea-pdf-article.md
+++ b/src/collections/resources/beyond-a-human-rightsbased-approach-to-ai-governance-promise-pitfalls-plea-pdf-article.md
@@ -5,7 +5,6 @@ source: "SSRN"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Beyond%20a%20Human%20Rights%20based%20approach%20to%20AI%20Governance%20Promise,%20Pitfalls,%20Plea.pdf"
 link: "https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3543112"
 keywords: ["Artificial Intelligence","ethics","human rights","AI governance","AI for good."]
 learnTags: ["ethics","framework","government","trust"]

--- a/src/collections/resources/bias-in-data-driven-artificial-intelligence-systems-an-introductory-survey-pdf-article.md
+++ b/src/collections/resources/bias-in-data-driven-artificial-intelligence-systems-an-introductory-survey-pdf-article.md
@@ -5,7 +5,6 @@ source: "WIREs Data Mining and Knowledge Discovery Journal"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Bias%20in%20data-driven%20artificial%20intelligence%20system.pdf"
 keywords: ["fairness","fairness-aware AI","fairness-aware machine learning","interpretability","responsible AI"]
 learnTags: ["bias","dataset","methods","ethics","fairness","government"]
 summary: "An overview of data bias, including understanding bias, mitigating bias, accounting bias and corresponding legal issues. "

--- a/src/collections/resources/bigdata-discrimination-in-data-supported-decision-making-pdf-article.md
+++ b/src/collections/resources/bigdata-discrimination-in-data-supported-decision-making-pdf-article.md
@@ -5,7 +5,6 @@ source: "EU FRA"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/%23BigData%20Discrimination%20in%20data-supported%20decision%20making.pdf"
 link: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/%23BigData%20Discrimination%20in%20data-supported%20decision%20making.pdf?csf=1&web=1&e=BND8ei"
 keywords: []
 learnTags: ["bias","ethics","fairness","framework","government","inclusivePractice","solution","trust"]

--- a/src/collections/resources/breaking-the-curse-of-small-datasets-in-machine-learning-part-1-blog.md
+++ b/src/collections/resources/breaking-the-curse-of-small-datasets-in-machine-learning-part-1-blog.md
@@ -5,7 +5,6 @@ source: "Towards Data Science"
 readability: ["Expert"]
 type: "Blog"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Breaking%20the%20curse%20of%20small%20datasets%20in%20Machine%20Learning%20Part%201.pdf"
 link: "https://towardsdatascience.com/breaking-the-curse-of-small-datasets-in-machine-learning-part-1-36f28b0c044d"
 keywords: []
 learnTags: ["bias","dataset","dataTools","smallData"]

--- a/src/collections/resources/bridging-the-gap-pdf-article.md
+++ b/src/collections/resources/bridging-the-gap-pdf-article.md
@@ -5,7 +5,6 @@ source: "AI and Ethics"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Bridging%20the%20Gap.pdf?csf=1&web=1&e=jzg7aK"
 keywords: ["Artificial intelligence","AI","Artificial intelligence policy","Long term","Short term","Artificial intelligence ethics","\nCooperation models","Incompletely theorized agreement","Overlapping consensus"]
 learnTags: ["ethics","solution"]
 summary: "A paper that proposes to make use of the principle of an \"incompletely theorized agreement\" to bridge some underlying disagreements between those in the research community in order to address AI’s urgent challenges. "

--- a/src/collections/resources/bringing-the-people-back-in-contesting-benchmark-machine-learning-datasets-pdf-article.md
+++ b/src/collections/resources/bringing-the-people-back-in-contesting-benchmark-machine-learning-datasets-pdf-article.md
@@ -5,7 +5,6 @@ source: "ICML Workshop on Participatory Approaches to Machine Learning 2020"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Bringing%20the%20People%20Back%20In.pdf?csf=1&web=1&e=ir2lhX"
 keywords: []
 learnTags: ["methods","ethics","framework"]
 summary: "A paper that outlines a research program — a genealogy of machine learning data — for investigating how and why datasets have been created, what and whose values influence the choices of data to collect, the contextual and contingent conditions of their creation. "

--- a/src/collections/resources/can-ai-hiring-systems-be-made-antiracist.md
+++ b/src/collections/resources/can-ai-hiring-systems-be-made-antiracist.md
@@ -6,7 +6,6 @@ readability:
   - Intermediate
 type: PDF Article
 openSource: true
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount-OptimizingDiversitywithDisabilityODDChannel/Shared%20Documents/Optimizing%20Diversity%20with%20Disability%20(ODD)%20Channel/Hiring%20Systems/Article%20+%20Resources/Can%20AI%20hiring%20systems%20be%20made%20antiracist.pdf?csf=1&web=1&e=J1D24o
 link: "https://ieeexplore.ieee.org/document/9173891 "
 learnTags:
   - bias

--- a/src/collections/resources/caveat-emptor-computational-social-science-large-scale-missing-data-in-a-widely-published-reddit-corpus-pdf-article.md
+++ b/src/collections/resources/caveat-emptor-computational-social-science-large-scale-missing-data-in-a-widely-published-reddit-corpus-pdf-article.md
@@ -5,7 +5,6 @@ source: "PLOS ONE"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Caveat%20emptor,%20computational%20social%20science.pdf"
 keywords: []
 learnTags: ["bias","dataset","dataTools","methods"]
 summary: "In this paper, the authors document the Reddit data set, substantial missing observations in the data set, and the risks to research validity that arise from those gaps.  "

--- a/src/collections/resources/centering-disability-perspectives-in-algorithmic-fairness-accountability-and-transparency-pdf-article.md
+++ b/src/collections/resources/centering-disability-perspectives-in-algorithmic-fairness-accountability-and-transparency-pdf-article.md
@@ -5,7 +5,6 @@ source: "FAT 2020"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Centering%20disability%20perspectives%20in%20algorithmic%20fairness_accountability%20and%20transparency.pdf"
 keywords: ["AI FATE","algorithmic bias","disability studies","accessibility"]
 learnTags: ["disability","ethics","fairness","inclusivePractice"]
 summary: "An abstract of a panel discussion held at the Conference on Fairness, Accountability and Transparency with experts in AI, disability advocacy and legal studies. "

--- a/src/collections/resources/changing-landscape-of-recruitment-industry-a-study-on-the-impact-of-artificial-intelligence-on-eliminating-hiring-bias-from-recruitment-and-selection-process.md
+++ b/src/collections/resources/changing-landscape-of-recruitment-industry-a-study-on-the-impact-of-artificial-intelligence-on-eliminating-hiring-bias-from-recruitment-and-selection-process.md
@@ -8,7 +8,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: false
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount-OptimizingDiversitywithDisabilityODDChannel/Shared%20Documents/Optimizing%20Diversity%20with%20Disability%20(ODD)%20Channel/Hiring%20Systems/Article%20+%20Resources/Changing%20Landscape%20of%20Recruitment%20Industry%20A%20study%20on%20the%20Impact%20of%20AI%20on%20Eliminating%20Hiring%20Bias.pdf?csf=1&web=1&e=FOoeuh
 link: https://www.researchgate.net/publication/347681335_Changing_Landscape_of_Recruitment_Industry_A_Study_on_the_Impact_of_Artificial_Intelligence_on_Eliminating_Hiring_Bias_from_Recruitment_and_Selection_Process
 keywords:
   - Artiﬁcial Intelligence

--- a/src/collections/resources/chartsense-interactive-data-extraction-from-chart-images-pdf-article.md
+++ b/src/collections/resources/chartsense-interactive-data-extraction-from-chart-images-pdf-article.md
@@ -6,7 +6,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: true
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/ChartSense%20Interactive%20Data%20Extraction%20from%20Chart%20Images.pdf?csf=1&web=1&e=b20IPB
 link: https://www.microsoft.com/en-us/research/wp-content/uploads/2017/02/ChartSense-CHI2017.pdf
 keywords:
   - Chart recognition

--- a/src/collections/resources/co-designing-checklists-to-understand-organizational-challenges-and-opportunities-around-fairness-in-ai-pdf-article.md
+++ b/src/collections/resources/co-designing-checklists-to-understand-organizational-challenges-and-opportunities-around-fairness-in-ai-pdf-article.md
@@ -5,7 +5,6 @@ source: "CHI 2020"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Co-Designing%20Checklists%20to%20Understand%20Organizational%20Challenges%20and%20Opportunities%20around%20Fairness%20in%20AI.pdf"
 keywords: ["AI","ML","ethics","fairness","co-design","checklists"]
 learnTags: ["ethics","fairness","framework","solution"]
 summary: "This article describes the results from a interview and co-design with 48 practitioners from 12 tech companies to understand the role of AI ethics checklists and how they should be developed. "

--- a/src/collections/resources/computings-social-obligation-pdf-article.md
+++ b/src/collections/resources/computings-social-obligation-pdf-article.md
@@ -5,7 +5,6 @@ source: "ACM Computers and Society Journal"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Computing's%20social%20obligation.pdf"
 keywords: ["Computing","Social Obligation","Ethics","Diversity"]
 learnTags: ["education","ethics","fairness"]
 summary: "An opinion piece on the need to integrate ethics in undergraduate computer science programs and for data scientists to view themselves as social activists. "

--- a/src/collections/resources/considerations-for-ai-fairness-for-people-with-disabilities-pdf-article.md
+++ b/src/collections/resources/considerations-for-ai-fairness-for-people-with-disabilities-pdf-article.md
@@ -5,7 +5,6 @@ source: "AI Matters"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Considerations%20for%20AI%20fairness%20for%20people%20with%20disabilities.pdf"
 keywords: []
 learnTags: ["bias","methods","disability","framework","inclusivePractice"]
 summary: "This paper recommends reviewing AI systems for their potential impact on the user in their broader context of use, and including people with disabilities when sourcing data to build models and when testing, to create a more inclusive and robust system. "

--- a/src/collections/resources/corporate-surveillance-in-everyday-life-pdf-article.md
+++ b/src/collections/resources/corporate-surveillance-in-everyday-life-pdf-article.md
@@ -5,7 +5,6 @@ source: "Cracked Labs"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Corporate%20Surveillance%20in%20Everyday%20Life.pdf"
 keywords: []
 learnTags: ["business","dataBroker","dataset","ethics","fairness","notForProfit"]
 summary: "A report explaining the practices and inner workings of the data industry and a description of the data ecosystem, including digital tracking and profiling, data collection and sharing, and relevant industry players and businesses.  "

--- a/src/collections/resources/counterfactual-fairness-pdf-article.md
+++ b/src/collections/resources/counterfactual-fairness-pdf-article.md
@@ -5,7 +5,6 @@ source: "NIPS 2017"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Counterfactual%20Fairness.pdf"
 keywords: []
 learnTags: ["bias","methods","ethics","fairness","framework","machineLearning","solution"]
 summary: "A machine learning framework for modelling fairness using tools from causal inference. "

--- a/src/collections/resources/coverage-of-artificial-intelligence-and-machine-learning-within-academic-literature-canadian-newspapers-and-twitter-tweets-the-case-of-disabled-people-pdf-article.md
+++ b/src/collections/resources/coverage-of-artificial-intelligence-and-machine-learning-within-academic-literature-canadian-newspapers-and-twitter-tweets-the-case-of-disabled-people-pdf-article.md
@@ -5,7 +5,6 @@ source: "Societies Journal"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Coverage%20of%20artificial%20intelligence%20and%20machine%20learning%20within%20academic%20literature,%20Canadian%20newspapers,%20and%20Twitter%20tweets_The%20case%20of%20disabled%20people.pdf"
 keywords: ["disabled people","people with disabilities","artificial intelligence","machine learning","scoping review","social good","for good"]
 learnTags: ["business","disability","government","inclusivePractice"]
 summary: "A scoping review from academic literature, Canadian newspapers and Twitter found limited coverage on persons with disabilities as knowledge producers or influencers of machine learning and AI technology, revealing a pressing need for changes to AI/ML coverage. "

--- a/src/collections/resources/critical-news-reading-with-twitter-exploring-data-mining-practices-and-their-impact-on-societal-discourse-pdf-article.md
+++ b/src/collections/resources/critical-news-reading-with-twitter-exploring-data-mining-practices-and-their-impact-on-societal-discourse-pdf-article.md
@@ -5,7 +5,6 @@ source: "Communications Journal"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Critical%20news%20reading%20with%20Twitter%20%20Exploring%20data-mining%20practices%20and%20their%20impact%20on%20societal%20discourse.pdf"
 link: "  "
 keywords: ["news analysis","Twitter analysis","big data","mixed media environment","multi-disciplinary approach"]
 learnTags: ["dataset","dataTools","methods","framework"]

--- a/src/collections/resources/data-broker-report-call-for-transparency-and-accountability-pdf-article.md
+++ b/src/collections/resources/data-broker-report-call-for-transparency-and-accountability-pdf-article.md
@@ -5,7 +5,6 @@ source: "U.S. Federal Trade Commission"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Data%20Broker%20Report.pdf"
 keywords: []
 learnTags: ["bias","business","dataBroker","dataset","dataTools","methods","ethics","fairness","government"]
 summary: "This federal report provides detailed information on the practices of major data brokers — Acxiom, Corelogic, Datalogix, eBureau, ID Analytics, Intelius, PeekYou, Rapleaf, and Recorded Future — and makes recommendations to Congress for data broker legislation and best practices. "

--- a/src/collections/resources/data-ethics-the-rise-in-morality-of-technology-pdf-article.md
+++ b/src/collections/resources/data-ethics-the-rise-in-morality-of-technology-pdf-article.md
@@ -5,7 +5,6 @@ source: "World Federation of Advertisers"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Data%20Ethics_The%20Rise%20of%20Morality%20in%20Technology.pdf"
 link: "https://wfanet.org/leadership/data-ethics-report"
 keywords: []
 learnTags: ["business","ethics"]

--- a/src/collections/resources/data-science-big-data-and-statistics-pdf-article.md
+++ b/src/collections/resources/data-science-big-data-and-statistics-pdf-article.md
@@ -6,7 +6,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: false
-sharePointUrl: https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Data%20Science%20Big%20Data%20And%20Statistic.pdf
 keywords:
   - Machine learning
   - Sparse model selection

--- a/src/collections/resources/datasheets-for-datasets-pdf-article.md
+++ b/src/collections/resources/datasheets-for-datasets-pdf-article.md
@@ -5,7 +5,6 @@ source: "arXiv"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Datasheets%20for%20Datasets.pdf"
 keywords: []
 learnTags: ["bias","dataset","methods","ethics","fairness","solution"]
 summary: "An extensive list of questions for data set creaters and consumers to use when creating and using data sets in order to make informed decisions and to avoid harm. "

--- a/src/collections/resources/deconstructing-community-based-collaborative-design-towards-more-equitable-participatory-design-engagement-pdf-article.md
+++ b/src/collections/resources/deconstructing-community-based-collaborative-design-towards-more-equitable-participatory-design-engagement-pdf-article.md
@@ -5,7 +5,6 @@ source: "CSCW 2019"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Deconstructing%20Community-Based%20Collaborative%20Design_Towards%20More%20Equitable%20Participatory%20Design%20Engagements.pdf"
 keywords: ["Design workshops","community-based participatory design","social action research","design equity"]
 learnTags: ["ethics","fairness","framework","inclusivePractice"]
 summary: "This article discusses the shortcomings of using a participatory model to engage marginalized groups in human-computer interaction (HCI) design and describes two case studies that show how underlying tensions between participants and researchers can undermine the purpose of the project. "

--- a/src/collections/resources/decoupled-classifiers-for-group-fair-and-efficient-machine-learning-pdf-article.md
+++ b/src/collections/resources/decoupled-classifiers-for-group-fair-and-efficient-machine-learning-pdf-article.md
@@ -5,7 +5,6 @@ source: "FAT 2018"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Decoupled%20Classifiers%20for%20Group-Fair%20and%20Efficient%20Machine%20Learning.pdf"
 keywords: []
 learnTags: ["bias","dataTools","methods","ethics","fairness","framework"]
 summary: "A decoupling technique used to minimize or avoid bias and unfairness that can be added to any black-box machine learning algorithm to learn different classifier from different groups. "

--- a/src/collections/resources/delayed-impact-of-fair-machine-learning-pdf-article.md
+++ b/src/collections/resources/delayed-impact-of-fair-machine-learning-pdf-article.md
@@ -5,7 +5,6 @@ source: "ICML 2018"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Delayed%20Impact%20of%20Fair%20Machine%20Learning.pdf"
 keywords: []
 learnTags: ["methods","fairness","framework","machineLearning"]
 summary: "A study how static fairness criteria interact with temporal indicators of well-being and highlight the importance of measurement and temporal modeling in the evaluation of fairness criteria. "

--- a/src/collections/resources/diagnosing-gender-bias-in-image-recognition-systems-pdf-article.md
+++ b/src/collections/resources/diagnosing-gender-bias-in-image-recognition-systems-pdf-article.md
@@ -5,7 +5,6 @@ source: "SOCIUS"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Diagnosing%20Gender%20Bias%20in%20Image%20Recognition%20Systems.pdf?csf=1&web=1&e=A64Ntq"
 link: "https://journals.sagepub.com/doi/pdf/10.1177/2378023120967171"
 keywords: ["gender","image recognition","computational social science","bias","stereotypes"]
 learnTags: ["bias","ethics","fairness"]

--- a/src/collections/resources/disability-bias-and-ai-pdf-article.md
+++ b/src/collections/resources/disability-bias-and-ai-pdf-article.md
@@ -5,7 +5,6 @@ source: "AI Now Institute"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Disability,%20bias,%20AI.pdf"
 keywords: []
 learnTags: ["bias","dataset","methods","disability","ethics","fairness","inclusivePractice","smallData"]
 summary: "A report capturing critical themes and discussions from a workshop at the AI NOW Institute at New York University, the NYU Center for Disability Studies.  "

--- a/src/collections/resources/disability-discrimination-using-ai-systems-social-media-and-digital-platforms-can-we-disable-digital-bias.md
+++ b/src/collections/resources/disability-discrimination-using-ai-systems-social-media-and-digital-platforms-can-we-disable-digital-bias.md
@@ -7,7 +7,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: false
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount-OptimizingDiversitywithDisabilityODDChannel/Shared%20Documents/Optimizing%20Diversity%20with%20Disability%20(ODD)%20Channel/Hiring%20Systems/Article%20+%20Resources/Changing%20Landscape%20of%20Recruitment%20Industry%20A%20study%20on%20the%20Impact%20of%20AI%20on%20Eliminating%20Hiring%20Bias.pdf?csf=1&web=1&e=FOoeuh
 link: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3724556
 keywords:
   - disability

--- a/src/collections/resources/discriminating-systems-gender-race-and-power-in-ai-pdf-article.md
+++ b/src/collections/resources/discriminating-systems-gender-race-and-power-in-ai-pdf-article.md
@@ -5,7 +5,6 @@ source: "AI Now Institute"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Discriminating%20Systems.pdf"
 keywords: []
 learnTags: ["bias","business","dataset","methods","employment","ethics","fairness","government","inclusivePractice"]
 summary: "This report provides evidence regarding the lack of diversity, discrimination and inequality in AI systems and the workplace, and offers recommendations to address these issues and the challenges ahead. "

--- a/src/collections/resources/discrimination-in-the-age-of-algorithms-pdf-article.md
+++ b/src/collections/resources/discrimination-in-the-age-of-algorithms-pdf-article.md
@@ -5,7 +5,6 @@ source: "SSRN "
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Discrimination%20in%20the%20Age%20of%20Algorithms.pdf"
 keywords: []
 learnTags: ["bias","ethics","fairness"]
 summary: "A legally framed discussion of discrimination and bias within algorithms. "

--- a/src/collections/resources/economic-theories-of-distributive-justice-for-fair-machine-learning-pdf-article.md
+++ b/src/collections/resources/economic-theories-of-distributive-justice-for-fair-machine-learning-pdf-article.md
@@ -5,7 +5,6 @@ source: "WWW 2019"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Economic%20Theories%20of%20Distributive%20Justice.pdf"
 keywords: ["social choice theory","equality of opportunity","inequality"]
 learnTags: ["ethics","fairness","framework","machineLearning"]
 summary: "An overview of fair machine learning through the ethical lens of prominent economic theories of distributive justice. "

--- a/src/collections/resources/effect-of-confidence-and-explanation-on-accuracy-and-trust-calibration-in-ai-assisted-decision-making-pdf-article.md
+++ b/src/collections/resources/effect-of-confidence-and-explanation-on-accuracy-and-trust-calibration-in-ai-assisted-decision-making-pdf-article.md
@@ -5,7 +5,6 @@ source: "FAT 2020"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Effect%20of%20Confidence%20and%20Explanation%20on%20Accuracy%20and%20Trust%20Calibration%20in%20AI-Assisted%20Decision%20Making.pdf"
 keywords: ["decision support","trust","confidence","explainable AI"]
 learnTags: ["bias","dataset","methods","ethics","framework","trust"]
 summary: "A case study of AI-assisted decision making in which humans and AI have comparable performance alone, and explores whether features that reveal case-specific model information can calibrate trust and improve the joint performance of the human and AI.  "

--- a/src/collections/resources/eliciting-programming-challenges-faced-by-developers-with-visual-impairments-exploratory-study-pdf-article.md
+++ b/src/collections/resources/eliciting-programming-challenges-faced-by-developers-with-visual-impairments-exploratory-study-pdf-article.md
@@ -5,7 +5,6 @@ source: "CHASE 2016"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Eliciting%20Programming%20Challenges%20Faced%20by%20Developers%20with%20Visual%20Impairments_Exploratory%20Study.pdf"
 keywords: ["Accessibility","Elicitation","Programmers","Visual Impairment","Programming","Challenges","Blind Programmers"]
 learnTags: ["disability","machineLearning","solution"]
 summary: "An empirical study of 69 survey responses by software developers with visual impairments to identify the challenges they face when developing software.   "

--- a/src/collections/resources/embedded-ethics-some-technical-and-ethical-challenges-pdf-article.md
+++ b/src/collections/resources/embedded-ethics-some-technical-and-ethical-challenges-pdf-article.md
@@ -5,7 +5,6 @@ source: "Ethics and Information Technology Journal"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Embedded%20ethics%20some%20technical%20and%20ethical%20challenges.pdf"
 keywords: ["Ethical dilemma","Ethical framework","Autonomous machines","Judgement","Subjectivity"]
 learnTags: ["methods","ethics","fairness","framework"]
 summary: "Various ethical frameworks are applied using mathematical concepts to determine if ethical decisions can be formalized in machines.  "

--- a/src/collections/resources/ethical-ai-in-the-data-ecosystem-environmental-scan-slide-deck.md
+++ b/src/collections/resources/ethical-ai-in-the-data-ecosystem-environmental-scan-slide-deck.md
@@ -6,7 +6,6 @@ readability:
   - Intermediate
 type: Slide Deck
 openSource: false
-sharePointUrl: https://ocaduniversity.sharepoint.com/teams/Team_WeCount/_layouts/15/Doc.aspx?OR=teams&action=edit&sourcedoc={90300DEE-FDA4-497F-9926-E736FDD008D4}
 keywords: []
 learnTags:
   - bias

--- a/src/collections/resources/ethical-ai-in-the-data-ecosystem-environmental-scan-video.md
+++ b/src/collections/resources/ethical-ai-in-the-data-ecosystem-environmental-scan-video.md
@@ -5,7 +5,6 @@ source: "We Count"
 readability: ["Intermediate"]
 type: "Video"
 openSource: false
-sharePointUrl: "\nhttps://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Ethical%20AI%20in%20the%20Data%20Ecosystem%20Environmental%20Scan_Final.mp4"
 keywords: []
 learnTags: ["bias","business","canadianLandscape","dataBroker","disability","education","ethics","fairness","inclusivePractice","machineLearning"]
 summary: "A video presentation of key findings from a data ecosystem environmental scan conducted by the We Count team. The scan covers three areas: post-secondary education, data service providers and AI Firms.  "

--- a/src/collections/resources/ethics-guidelines-for-trustworthy-ai-pdf-article.md
+++ b/src/collections/resources/ethics-guidelines-for-trustworthy-ai-pdf-article.md
@@ -5,7 +5,6 @@ source: "European Commission"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Ethics%20Guidelines%20for%20Trustworthy%20AI.pdf"
 keywords: []
 learnTags: ["ethics","fairness","framework","trust"]
 summary: "The European Commission's guidelines for trustworthy AI offers a framework for fostering ethical and robust AI. "

--- a/src/collections/resources/ethics-identity-and-political-vision-toward-a-justice-centered-approach-to-equity-in-computer-science-education-pdf-article.md
+++ b/src/collections/resources/ethics-identity-and-political-vision-toward-a-justice-centered-approach-to-equity-in-computer-science-education-pdf-article.md
@@ -5,7 +5,6 @@ source: "Harvard Educational Review"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Ethics,%20identity,%20and%20political%20vision_toward%20a%20justice-centered%20approach%20to%20equity%20in%20computer%20science%20education.pdf"
 keywords: ["computer science education","critical theory","STEM education","ethics","sociocultural theory"]
 learnTags: ["ethics","fairness","framework","inclusivePractice"]
 summary: "This essay takes a critical look at current computer science curriculum and argues for a justice-centred approach to public school computer science education to ensure issues of equity and any ethical and political implications are addressed. "

--- a/src/collections/resources/ethics-of-artificial-intelligence-some-ethical-issues-and-regulatory-challenges-pdf-article.md
+++ b/src/collections/resources/ethics-of-artificial-intelligence-some-ethical-issues-and-regulatory-challenges-pdf-article.md
@@ -5,7 +5,6 @@ source: "Technology and Regulation Journal"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Ethics%20of%20artificial%20intelligence_Some%20ethical%20issues%20and%20regulatory%20challenges.pdf"
 keywords: []
 learnTags: ["bias","methods","ethics","fairness"]
 summary: "An overview of ethical issues in AI, including privacy, transparency and bias, and what steps need to be taken to address these issues. "

--- a/src/collections/resources/ethics-owners-a-new-model-of-organizational-responsibility-in-data-driven-technology-companies-pdf-article.md
+++ b/src/collections/resources/ethics-owners-a-new-model-of-organizational-responsibility-in-data-driven-technology-companies-pdf-article.md
@@ -5,7 +5,6 @@ source: "Data and Society"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Ethics%20Owners.pdf?csf=1&web=1&e=pDHCk0"
 link: "https://datasociety.net/wp-content/uploads/2020/09/Ethics-Owners_20200923-DataSociety.pdf"
 keywords: []
 learnTags: ["bias","business","ethics","inclusivePractice"]

--- a/src/collections/resources/ethics‑based-auditing-of-automated-decision‑making-systems-intervention-points-and-policy-implications.md
+++ b/src/collections/resources/ethics‑based-auditing-of-automated-decision‑making-systems-intervention-points-and-policy-implications.md
@@ -7,7 +7,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: false
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Ethics-Based%20Auditing%20of%20Automated%20Decision-Making%20Systems.pdf?csf=1&web=1&e=gfiZBq
 link: https://link.springer.com/article/10.1007/s00146-021-01286-x
 keywords:
   - Artificial Intelligence

--- a/src/collections/resources/examining-the-black-box-tools-for-assessing-algorithmic-systems-pdf-article.md
+++ b/src/collections/resources/examining-the-black-box-tools-for-assessing-algorithmic-systems-pdf-article.md
@@ -5,7 +5,6 @@ source: "Ada Lovelace Institute"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Examining%20the%20Black%20Box.pdf?csf=1&web=1&e=MLZ8n8"
 keywords: []
 learnTags: ["dataTools","methods","framework","researchCentre"]
 summary: "A report that clarifies terms in algorithm audits and algorithmic impact assessments, and the current state of research and practice. "

--- a/src/collections/resources/explainable-machine-learning-in-deployment-pdf-article.md
+++ b/src/collections/resources/explainable-machine-learning-in-deployment-pdf-article.md
@@ -5,7 +5,6 @@ source: "FAT 2020"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Explainable%20Machine%20Learning%20in%20Deployment.pdf"
 keywords: ["machine learning","explainability","transparency","deployed systems,\nqualitative study"]
 learnTags: ["methods","framework","machineLearning"]
 summary: "A study that analyzes the limits of current explainable machine learning techniques for end users and proposes a framework for establishing clear guidelines for explainability. "

--- a/src/collections/resources/facial-recognition-technologies-a-primer-pdf-article.md
+++ b/src/collections/resources/facial-recognition-technologies-a-primer-pdf-article.md
@@ -5,7 +5,6 @@ source: "Algorithmic Justice League"
 readability: ["Beginner"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Facial%20Recognition%20Technologies%20-%20A%20Primer.pdf"
 keywords: []
 learnTags: ["basicAI","bias","dataTools","ethics","fairness","machineLearning","notForProfit"]
 summary: "A facial recognition technologies primer written for a non-technical audience to provide background on the topic. "

--- a/src/collections/resources/facial-recognition-technologies-in-the-wild-a-call-for-a-federal-office-pdf-article.md
+++ b/src/collections/resources/facial-recognition-technologies-in-the-wild-a-call-for-a-federal-office-pdf-article.md
@@ -5,7 +5,6 @@ source: "Algorithmic Justice League"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Facial%20Recognition%20Technologies%20in%20the%20Wild.pdf"
 keywords: []
 learnTags: ["bias","ethics","fairness","framework","government","notForProfit"]
 summary: "A white paper asserts that the assessment of the risks and benefits of facial recognition technologies requires a new U.S. federal office. "

--- a/src/collections/resources/fair-decision-making-using-privacy-protected-data-pdf-article.md
+++ b/src/collections/resources/fair-decision-making-using-privacy-protected-data-pdf-article.md
@@ -5,7 +5,6 @@ source: "FAT 2020"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Fair%20decision%20making%20using%20privacy-protected%20data.pdf"
 link: "https://arxiv.org/abs/1905.12744"
 keywords: []
 learnTags: ["bias","dataset","methods","ethics","fairness"]

--- a/src/collections/resources/fair-regression-quantitative-definitions-and-reduction-based-algorithms-pdf-article.md
+++ b/src/collections/resources/fair-regression-quantitative-definitions-and-reduction-based-algorithms-pdf-article.md
@@ -5,7 +5,6 @@ source: "ICML 2019"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Fair%20Regression-%20Quantitative%20Definitions%20and%20Reduction-Based%20Algorithms.pdf"
 keywords: []
 learnTags: ["dataTools","methods","inclusivePractice","smallData","solution"]
 summary: "As machine learning touches increasingly critical aspects of our life, including education, healthcare, criminal justice and lending, there is a growing focus on ensuring that algorithms treat various subpopulations fairly. This paper seeks to diminish this gap by developing efficient algorithms for a substantially broader set of regression tasks and model classes. "

--- a/src/collections/resources/fair-transparent-and-accountable-algorithmic-decision-making-processes-pdf-article.md
+++ b/src/collections/resources/fair-transparent-and-accountable-algorithmic-decision-making-processes-pdf-article.md
@@ -5,7 +5,6 @@ source: "Springer Philosophy and Technology Journal"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Fair,%20Transparent,%20and%20Accountable%20Algorithmic%20Decision-Making%20Processes.pdf"
 keywords: ["algorithmic decision-making","  algorithmic transparency","  fairness","accountability"," social good"]
 learnTags: ["ethics","fairness","machineLearning","trust"]
 summary: "This paper provides an overview of available technical solutions to enhance fairness, accountability and transparency in algorithmic decision-making and highlights the criticality of engaging multidisciplinary teams to co-develop, deploy and evaluate algorithms designed to maximize fairness and transparency. "

--- a/src/collections/resources/fairlearn-a-toolkit-for-assessing-and-improving-fairness-in-ai-pdf-article.md
+++ b/src/collections/resources/fairlearn-a-toolkit-for-assessing-and-improving-fairness-in-ai-pdf-article.md
@@ -5,7 +5,6 @@ source: "Microsoft"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Fairlearn_A%20toolkitfor%20assessing%20and%20improving%20fairness%20in%20AI_Whitepaper.pdf"
 link: "https://www.microsoft.com/en-us/research/uploads/prod/2020/05/Fairlearn_whitepaper.pdf"
 keywords: []
 learnTags: ["bias","dataTools","methods","fairness","framework","inclusivePractice","solution","trust"]

--- a/src/collections/resources/fairness-and-abstraction-in-sociotechnical-systems-pdf-article.md
+++ b/src/collections/resources/fairness-and-abstraction-in-sociotechnical-systems-pdf-article.md
@@ -5,7 +5,6 @@ source: "Data and Society "
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Fairness%20and%20Abstraction%20in%20Sociotechnical%20Systems.pdf"
 keywords: []
 learnTags: ["methods","ethics","framework","machineLearning","researchCentre"]
 summary: "An article that outlines five traps that fair-ML work can fall into — framing, portability, formalism, ripple effect and solutionism — even though it tries to be more context-aware than traditional data science. "

--- a/src/collections/resources/from-principles-to-practice-how-can-we-make-ai-ethics-measurable-website-article.md
+++ b/src/collections/resources/from-principles-to-practice-how-can-we-make-ai-ethics-measurable-website-article.md
@@ -5,7 +5,6 @@ source: "Ethics of Algorithms"
 readability: ["Intermediate"]
 type: "Website Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/from%20principles%20to%20practise.pdf"
 link: "https://ethicsofalgorithms.org/2020/04/02/from-principles-to-practice-how-can-we-make-ai-ethics-measurable/"
 keywords: []
 learnTags: ["dataTools","methods","ethics","fairness","framework"]

--- a/src/collections/resources/gender-shades-intersectional-accuracy-disparities-in-commercial-gender-classification-pdf-article.md
+++ b/src/collections/resources/gender-shades-intersectional-accuracy-disparities-in-commercial-gender-classification-pdf-article.md
@@ -5,7 +5,6 @@ source: "Gender Shades "
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Gender%20Shades.pdf"
 keywords: ["Computer Vision","Algorithmic Audit","Gender Classification"]
 learnTags: ["bias","business","dataTools","methods","fairness","machineLearning","researchCentre"]
 summary: "This research paper a method for evaluating gender and racial bias in AI facial analysis algorithms and datasets using the Fitzpatrick Skin Type classification system. "

--- a/src/collections/resources/global-strategy-on-digital-health-pdf-article.md
+++ b/src/collections/resources/global-strategy-on-digital-health-pdf-article.md
@@ -5,7 +5,6 @@ source: "WHO"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/WHO%20Draft%20global%20strategy%20on%20digital%20health%202020-2024.pdf"
 keywords: []
 learnTags: ["disability","ethics","fairness","government"]
 summary: "This WHO paper outlines a global strategy to implement and govern person-centred digital health strategies by outlining outcomes, actions and target impacts for a healthier global population. "

--- a/src/collections/resources/governance-of-artificial-intelligence.md
+++ b/src/collections/resources/governance-of-artificial-intelligence.md
@@ -6,7 +6,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: false
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Governance%20of%20artificial%20intelligence.pdf?csf=1&web=1&e=a2Pwdo
 link: https://www.tandfonline.com/doi/full/10.1080/14494035.2021.1928377
 keywords:
   - Governance; artificial intelligence; AI; robotics; public policy

--- a/src/collections/resources/hack-weeks-as-a-model-for-data-science-education-and-collaboration-pdf-article.md
+++ b/src/collections/resources/hack-weeks-as-a-model-for-data-science-education-and-collaboration-pdf-article.md
@@ -5,7 +5,6 @@ source: "PNAS"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Hack%20weeks%20as%20a%20model%20for%20data%20science%20educaiton%20and%20collaboration.pdf"
 keywords: ["data science","education","interdisciplinary collaboration","reproducibility"]
 learnTags: ["inclusivePractice","solution"]
 summary: "A look at how hack weeks present an effective, easy-to-implement, fairly low-cost tool that can positively impact data analysis literacy in academic disciplines, foster collaboration, and cultivate best practices. "

--- a/src/collections/resources/hiring-algorithms-an-ethnography-of-fairness-in-practice.md
+++ b/src/collections/resources/hiring-algorithms-an-ethnography-of-fairness-in-practice.md
@@ -6,7 +6,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: true
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount-OptimizingDiversitywithDisabilityODDChannel/Shared%20Documents/Optimizing%20Diversity%20with%20Disability%20(ODD)%20Channel/Hiring%20Systems/Article%20+%20Resources/Hiring%20Algorithms%20An%20Ethnography%20of%20Fairness%20in%20Practice.pdf?csf=1&web=1&e=VQ9gEN
 link: "https://core.ac.uk/download/pdf/301385085.pdf "
 keywords:
   - Artificial Intelligence

--- a/src/collections/resources/holistic-user-models-for-cognitive-disabilities-personalized-tools-for-supporting-people-with-autism-in-the-city-pdf-article.md
+++ b/src/collections/resources/holistic-user-models-for-cognitive-disabilities-personalized-tools-for-supporting-people-with-autism-in-the-city-pdf-article.md
@@ -5,7 +5,6 @@ source: "UMAP 2018"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Holistic%20User%20Models%20for%20Cognitive%20Disabilities_Personalized%20Tools%20for%20Supporting%20People%20with%20Autism%20in%20the%20City.pdf"
 keywords: ["Adaptive support","recommender systems","assistive technologies,\nmaps","autism","real world user model","holistic user model. "]
 learnTags: ["dataTools","methods","disability","solution"]
 summary: "The PIUMA (Personalized Interactive Urban Maps for Autism) project has the goal of developing a set of personalized solutions that account for the ASD individual's idiosyncrasies, helping them move across the city where they live and improving their autonomy when moving and managing everyday activities.  "

--- a/src/collections/resources/hour-of-code.md
+++ b/src/collections/resources/hour-of-code.md
@@ -6,7 +6,6 @@ readability:
   - Beginner
 type: Website Resource
 openSource: false
-sharePointUrl: ""
 link: https://hourofcode.com/ca/how-to/virtual
 learnTags:
   - education

--- a/src/collections/resources/how-ai-is-helping-social-program-management-to-be-accessible-website-resource.md
+++ b/src/collections/resources/how-ai-is-helping-social-program-management-to-be-accessible-website-resource.md
@@ -5,7 +5,6 @@ source: "IBM"
 readability: ["Intermediate"]
 type: "Website Resource"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/How%20AI%20is%20helping%20Social%20Program%20IBM%20Watson%20Health%20Community.pdf"
 keywords: []
 learnTags: ["dataTools","disability","inclusivePractice","solution"]
 summary: "The IBM Social Program Management development team is using artificial intelligence to improve the experience of its products for users with disabilities by adopting AI to Social Program Management and using a browser plug-in tool to identify potential violations and get suggested solutions to fix them. "

--- a/src/collections/resources/how-do-fair-decisions-fare-in-long-term-qualification-pdf-article.md
+++ b/src/collections/resources/how-do-fair-decisions-fare-in-long-term-qualification-pdf-article.md
@@ -5,7 +5,6 @@ source: "NeurIPS 2020"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/How%20Do%20Fair%20Decisions%20Fare%20in%20Long-Term%20Qualification.pdf?csf=1&web=1&e=UcdxrT"
 keywords: []
 learnTags: ["bias","fairness","framework"]
 summary: "A paper that studies the dynamics of population qualification and algorithmic decisions to analyze the long-term impact of static fairness constraints on the equality and improvement of group well-being. "

--- a/src/collections/resources/how-to-design-ai-that-eliminates-disability-bias-pdf-article.md
+++ b/src/collections/resources/how-to-design-ai-that-eliminates-disability-bias-pdf-article.md
@@ -5,7 +5,6 @@ source: "Financial Times"
 readability: ["Beginner"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/How%20to%20design%20AI%20that%20eliminates%20disability%20bias%20Financial%20Times.pdf"
 link: "https://www.ft.com/content/f5bd21da-33b8-11ea-a329-0bcf87a328f2"
 keywords: []
 learnTags: ["bias","disability","ethics","fairness"]

--- a/src/collections/resources/iccesomar-international-code-on-market-opinion-and-social-research-and-data-analytics-pdf-article.md
+++ b/src/collections/resources/iccesomar-international-code-on-market-opinion-and-social-research-and-data-analytics-pdf-article.md
@@ -5,7 +5,6 @@ source: "ICC"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/ICCESOMAR%20Code.pdf"
 keywords: []
 learnTags: ["ethics","fairness","framework"]
 summary: "This code is designed to be a comprehensive framework for self-regulation for those engaged in market, opinion and social research and data analytics with the aim of maintaining public confidence in research, ensuring researchers and analysts meet their ethical and legal responsibilities, and safeguarding the right of researchers to seek, receive and impart information. "

--- a/src/collections/resources/image-cropping-on-twitter-fairness-metrics-their-limitations-and-the-importance-of-representation-design-and-agency.md
+++ b/src/collections/resources/image-cropping-on-twitter-fairness-metrics-their-limitations-and-the-importance-of-representation-design-and-agency.md
@@ -7,7 +7,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: false
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Image%20Cropping%20on%20Twitter.pdf?csf=1&web=1&e=EeYWkG
 link: https://arxiv.org/pdf/2105.08667.pdf
 keywords:
   - image cropping

--- a/src/collections/resources/improving-fairness-in-machine-learning-systems-what-do-industry-practitioners-need-pdf-article.md
+++ b/src/collections/resources/improving-fairness-in-machine-learning-systems-what-do-industry-practitioners-need-pdf-article.md
@@ -5,7 +5,6 @@ source: "CHI 2019"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Improving%20fairness%20in%20machine%20learning%20systems-%20What%20do%20industry%20practitioners%20need.pdf"
 keywords: ["algorithmic bias","fair machine learning","product teams","needfinding","empirical study","UX of machine learnin"]
 learnTags: ["bias","business","methods","ethics","fairness","inclusivePractice","solution"]
 summary: "Through 35 semi-structured interviews and an anonymous survey of 267 ML practitioners, the first systematic investigation of commercial product teams’ challenges and needs for support in developing fairer machine learning systems is presented.  "

--- a/src/collections/resources/inclusive-data-visualization-for-people-with-disabilities-a-call-to-action.md
+++ b/src/collections/resources/inclusive-data-visualization-for-people-with-disabilities-a-call-to-action.md
@@ -6,7 +6,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: false
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Inclusive%20Data%20Visualization%20for%20People%20with%20Disabilities.pdf?csf=1&web=1&e=rmpUXP
 link: https://dl.acm.org/doi/10.1145/3457875
 learnTags:
   - bias

--- a/src/collections/resources/inclusive-intelligence-artificial-intelligence-in-the-service-of-science-work-and-the-public-good-pdf-article.md
+++ b/src/collections/resources/inclusive-intelligence-artificial-intelligence-in-the-service-of-science-work-and-the-public-good-pdf-article.md
@@ -5,7 +5,6 @@ source: "UC Berkeley"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/inclusive_intelligence_draft_april_2019.pdf"
 keywords: []
 learnTags: ["education","ethics"]
 summary: "This report explores the rationale and need for a cross-disciplinary AI program at UC Berkley. "

--- a/src/collections/resources/indigenous-protocol-and-artificial-intelligence-pdf-article.md
+++ b/src/collections/resources/indigenous-protocol-and-artificial-intelligence-pdf-article.md
@@ -5,7 +5,6 @@ source: "The Initiative for Indigenous Futures and CIFAR"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Indigenous_Protocol_and_AI_2020.pdf?csf=1&web=1&e=W7GQta"
 link: "https://spectrum.library.concordia.ca/986506/7/Indigenous_Protocol_and_AI_2020.pdf"
 keywords: []
 learnTags: ["ethics","framework","trust"]

--- a/src/collections/resources/integrating-ethics-within-machine-learning-courses-pdf-article.md
+++ b/src/collections/resources/integrating-ethics-within-machine-learning-courses-pdf-article.md
@@ -5,7 +5,6 @@ source: "ACM Transactions on Computing Education Journal"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Integrating%20Ethics%20within%20Machine-learning%20Courses.pdf"
 link: "https://dl.acm.org/doi/fullHtml/10.1145/3341164"
 keywords: ["Machine learning","ethics","education"]
 learnTags: ["education","ethics","fairness"]

--- a/src/collections/resources/integrating-fatecritical-data-studies-into-data-science-curricula-where-are-we-going-and-how-do-we-get-there-pdf-article.md
+++ b/src/collections/resources/integrating-fatecritical-data-studies-into-data-science-curricula-where-are-we-going-and-how-do-we-get-there-pdf-article.md
@@ -5,7 +5,6 @@ source: "FAT 2020"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Integrating%20FATE_critical%20data%20studies%20into%20data%20science%20curricula-%20where%20are%20we%20going%20and%20how%20do%20we%20get%20there.pdf"
 keywords: []
 learnTags: ["education","ethics","fairness"]
 summary: "A qualitative study reflecting and confirming the need to integrate ideas of fairness, accountability, transparency and ethics (FATE) and social justice into the Data Science curriculum at University of Sheffield. "

--- a/src/collections/resources/interventions-for-ranking-in-the-presence-of-implicit-bias-pdf-article.md
+++ b/src/collections/resources/interventions-for-ranking-in-the-presence-of-implicit-bias-pdf-article.md
@@ -5,7 +5,6 @@ source: "FAT 2020"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Interventions%20for%20Ranking%20in%20the%20Presence%20of%20Implicit%20Bias.pdf"
 keywords: []
 learnTags: ["bias","dataTools","methods","employment","ethics","fairness","inclusivePractice","solution"]
 summary: "This paper considers a type of constraint-based interventions for re-ordering biased rankings derived from utilities with systematic biases against a particular socially salient group. The goal of these interventions is to recover the unbiased ranking that would have resulted from the true latent (unbiased) utilities.  "

--- a/src/collections/resources/introduction-to-ethical-ai-principles-pdf-article.md
+++ b/src/collections/resources/introduction-to-ethical-ai-principles-pdf-article.md
@@ -5,7 +5,6 @@ source: "MAIEI"
 readability: ["Beginner","Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Introduction%20to%20Ethical%20AI%20Principles.pdf?csf=1&web=1&e=gzwzvb"
 link: "https://montrealethics.ai/introduction-to-ethical-ai-principles/"
 keywords: []
 learnTags: ["basicAI","ethics","researchCentre"]

--- a/src/collections/resources/invest-in-canada-big-data-and-analytics-in-canada-pdf-article.md
+++ b/src/collections/resources/invest-in-canada-big-data-and-analytics-in-canada-pdf-article.md
@@ -5,7 +5,6 @@ source: "Global Affairs Canada "
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Invest%20in%20Canada_Big%20data%20and%20analytics%20in%20Canada.pdf"
 keywords: []
 learnTags: ["business","canadianLandscape","employment","government"]
 summary: "An overview of how the growing big data and analytics requirements of major Canadian and global organizations have created opportunities in Canada for the leading global companies in those spaces. "

--- a/src/collections/resources/joint-optimization-of-ai-fairness-and-utility-a-human-centered-approach-pdf-article.md
+++ b/src/collections/resources/joint-optimization-of-ai-fairness-and-utility-a-human-centered-approach-pdf-article.md
@@ -5,7 +5,6 @@ source: "AIES 2020"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Joint%20Optimization%20of%20AI%20Fairness%20and%20Utility-%20A%20Human-Centered%20Approach.pdf"
 keywords: []
 learnTags: ["bias","methods","ethics","fairness","framework","machineLearning","solution"]
 summary: "A proposed framework to assist policy makers in choosing a machine learning model that maximizes fairness within the constraints of the policy. "

--- a/src/collections/resources/knowledge-design-towards-an-inclusive-ai-design-practice-pdf-article.md
+++ b/src/collections/resources/knowledge-design-towards-an-inclusive-ai-design-practice-pdf-article.md
@@ -5,7 +5,6 @@ source: "AAAI 2018"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Towards%20an%20Inclusive%20AI%20Design.pdf"
 keywords: []
 learnTags: ["basicAI","ethics","fairness","inclusivePractice"]
 summary: "This article demonstrates how using a co-creative model, virtual meetings and physical engagement in AI design research can be more inclusive for those who do not traditionally participate due to race, gender, computer literacy and geography. "

--- a/src/collections/resources/less-than-one-shot-learning-learning-n-classes-from-mlessn-samples-pdf-article.md
+++ b/src/collections/resources/less-than-one-shot-learning-learning-n-classes-from-mlessn-samples-pdf-article.md
@@ -5,7 +5,6 @@ source: "University of Waterloo"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/'Less%20Than%20One'-Shot%20Learning.pdf"
 keywords: []
 learnTags: ["dataset","dataTools","methods","framework","machineLearning","smallData"]
 summary: "A paper that discusses how deep neural networks require large training sets but suffer from high computational cost and long training times, and how training on much smaller training sets while maintaining nearly the same accuracy would be very beneficial.  "

--- a/src/collections/resources/making-the-future-of-work-inclusive-of-people-with-disabilities-pdf-article.md
+++ b/src/collections/resources/making-the-future-of-work-inclusive-of-people-with-disabilities-pdf-article.md
@@ -5,7 +5,6 @@ source: "Fundación ONCE and the ILO Global Business and Disability Network"
 readability: ["Beginner"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Making%20the%20future%20of%20work%20inclusive%20of%20people%20with%20disabilities.pdf"
 keywords: []
 learnTags: ["business","disability","education","employment","government","inclusivePractice"]
 summary: "A joint publication by Fundación ONCE and the ILO Global Business and Disability Network to connect different areas of debate, looking at the key trends of the future of work from a disability perspective and seeking to identify specific action needed in order to shape the future of work in a more disability-inclusive way. "

--- a/src/collections/resources/manipulating-and-measuring-model-interpretability-pdf-article.md
+++ b/src/collections/resources/manipulating-and-measuring-model-interpretability-pdf-article.md
@@ -5,7 +5,6 @@ source: "arXiv"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Manipulating%20and%20Measuring%20Model%20Interpretability.pdf"
 keywords: []
 learnTags: ["machineLearning"]
 summary: "A series of experiments determined that providing information to participants meant to increase interpretability of decision-making models had negligible and detrimental effects, suggesting more rigorous work needs to be done to improve interpretability of models. "

--- a/src/collections/resources/methodology-for-heuristic-evaluation-of-the-accessibility-of-statistical-charts-for-people-with-low-vision-and-color-vision-deficiency-pdf-article.md
+++ b/src/collections/resources/methodology-for-heuristic-evaluation-of-the-accessibility-of-statistical-charts-for-people-with-low-vision-and-color-vision-deficiency-pdf-article.md
@@ -5,7 +5,6 @@ source: "Universitat de Lleida"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Methodology%20for%20Heuristic%20Evaluation%20of%20the%20Accessibility%20of%20Statistical%20Charts.pdf?csf=1&web=1&e=OcCfSZ"
 link: "https://assets.researchsquare.com/files/rs-156959/v1/9a255150-c14d-4958-8b0e-1dbf52b2b4af.pdf"
 keywords: ["Accessibility","Charts","Graphs","Information visualization","Low-vision","Colour blindness","Heuristic evaluation"]
 learnTags: ["disability","inclusivePractice","solution"]

--- a/src/collections/resources/microsoft-corporation-champions-ai-in-health-and-mobility-sector-website-resource.md
+++ b/src/collections/resources/microsoft-corporation-champions-ai-in-health-and-mobility-sector-website-resource.md
@@ -5,7 +5,6 @@ source: "Access and Mobility Professional"
 readability: ["Beginner"]
 type: "Website Resource"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Microsoft%20Corporation%20champions%20AI%20in%20health%20.pdf"
 link: "https://www.accessandmobilityprofessional.com/microsoft-corporation-champions-ai-in-health-and-mobility-sector/"
 keywords: []
 learnTags: ["basicAI","disability"]

--- a/src/collections/resources/modeling-epistemological-principles-for-bias-mitigation-in-ai-systems-an-illustration-in-hiring-decisions.md
+++ b/src/collections/resources/modeling-epistemological-principles-for-bias-mitigation-in-ai-systems-an-illustration-in-hiring-decisions.md
@@ -7,7 +7,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: true
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount-OptimizingDiversitywithDisabilityODDChannel/Shared%20Documents/Optimizing%20Diversity%20with%20Disability%20(ODD)%20Channel/Hiring%20Systems/Article%20+%20Resources/Modeling%20Epistemological%20Principles%20for%20Bias%20Mitigation%20in%20AI%20Systems.pdf?csf=1&web=1&e=etlwkV
 link: "https://arxiv.org/pdf/1711.07111.pdf "
 learnTags:
   - bias

--- a/src/collections/resources/motivations-and-risks-of-machine-ethics-pdf-article.md
+++ b/src/collections/resources/motivations-and-risks-of-machine-ethics-pdf-article.md
@@ -5,7 +5,6 @@ source: "IEEE"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Motivations%20and%20Risks%20of%20Machine%20Ethics.pdf"
 keywords: ["Ethical alignment","ethical reasoning","machine agency","machine ethics"]
 learnTags: ["ethics","fairness","machineLearning"]
 summary: "This paper surveys reasons for and against pursuing the field of machine ethics, and clarifies the nature of this goal, why it is worth pursuing, and the risks involved in its pursuit. "

--- a/src/collections/resources/my-algorithms-have-determined-youre-not-human-ai-ml-reverse-turing-tests-and-the-disability-experience-pdf-article.md
+++ b/src/collections/resources/my-algorithms-have-determined-youre-not-human-ai-ml-reverse-turing-tests-and-the-disability-experience-pdf-article.md
@@ -7,7 +7,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: false
-sharePointUrl: https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/My%20Algorithms%20Have%20Determined%20You're%20Not%20Human.pdf
 keywords:
   - Artificial intelligence
   - deep neural networks

--- a/src/collections/resources/neurotechnologies-connecting-human-brains-to-computers-and-related-ethical-challenges-pdf-article.md
+++ b/src/collections/resources/neurotechnologies-connecting-human-brains-to-computers-and-related-ethical-challenges-pdf-article.md
@@ -5,7 +5,6 @@ source: "Parliamentary Technical Advisory (Chile)"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Neurotechnologies-%20Connecting%20Human%20Brains%20to%20Computers%20and%20Related%20Ethical%20Challenges.pdf"
 keywords: []
 learnTags: ["methods","disability","ethics","fairness","government"]
 summary: "Impressive innovations have been developed to facilitate communication between the brain and electronic devices. Ethical and policy discussions around the responsible use of human data are occurring in many different countries, as they seek to build an urgently needed framework. "

--- a/src/collections/resources/owning-ethics-corporate-logics-silicon-valley-and-the-institutionalization-of-ethics-pdf-article.md
+++ b/src/collections/resources/owning-ethics-corporate-logics-silicon-valley-and-the-institutionalization-of-ethics-pdf-article.md
@@ -5,7 +5,6 @@ source: "Data and Society"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Owning%20Ethics.pdf"
 link: "https://datasociety.net/wp-content/uploads/2019/09/Owning-Ethics-PDF-version-2.pdf"
 keywords: []
 learnTags: ["ethics","fairness","framework","researchCentre"]

--- a/src/collections/resources/p5-access-project-making-creative-coding-accessible-to-screen-reader-users-website-resource.md
+++ b/src/collections/resources/p5-access-project-making-creative-coding-accessible-to-screen-reader-users-website-resource.md
@@ -5,7 +5,6 @@ source: "NYU Ability Project"
 readability: ["Intermediate"]
 type: "Website Resource"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/NYU%20Ability%20Project.pdf"
 keywords: []
 learnTags: ["basicAI","dataTools","disability","inclusivePractice","solution"]
 summary: "This project is an attempt to level the playing field with people who have low vision or blindness and want to learn to code. "

--- a/src/collections/resources/path-specific-counterfactual-fairness-pdf-article.md
+++ b/src/collections/resources/path-specific-counterfactual-fairness-pdf-article.md
@@ -5,7 +5,6 @@ source: "AAAI 2019"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Path-Specific%20Counterfactual%20Fairness.pdf"
 keywords: []
 learnTags: ["bias","methods","ethics","fairness","framework","machineLearning","solution"]
 summary: "A fairness framework that considers the problem of fairness modelling that is path specific and broken into fair and unfair pathways. "

--- a/src/collections/resources/physics-webpages-create-barriers-to-participation-for-people-with-disabilities-pdf-article.md
+++ b/src/collections/resources/physics-webpages-create-barriers-to-participation-for-people-with-disabilities-pdf-article.md
@@ -5,7 +5,6 @@ source: "International Journal of STEM Education"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Physics%20Webpages%20Create%20Barriers%20to%20Participation%20for%20People%20with%20Disabilities.pdf?csf=1&web=1&e=0eeClG"
 keywords: ["Accessibility","Webpage accessibility","STEM","Physics Education","Americans with Disabilities Act","Section 508","Disability studies"]
 learnTags: ["methods","disability","education","ethics","fairness","solution"]
 summary: "In this paper, five common accessibility errors identified on university physics webpages are presented, solutions for these errors are suggested, and the implications of these errors are discussed. "

--- a/src/collections/resources/pots-protective-optimization-technologies-pdf-article.md
+++ b/src/collections/resources/pots-protective-optimization-technologies-pdf-article.md
@@ -5,7 +5,6 @@ source: "FAT 2020"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Protective%20Optimization%20Technologies.pdf"
 keywords: ["Fairness and Accountability","Protective Optimization Technologie"]
 learnTags: ["methods","ethics","fairness","solution"]
 summary: "An overview of a new framework called POTs that draws on a systems framework to manage harms rather than using the fairness framework.  "

--- a/src/collections/resources/private-accountability-in-the-age-of-artificial-intelligence-pdf-article.md
+++ b/src/collections/resources/private-accountability-in-the-age-of-artificial-intelligence-pdf-article.md
@@ -5,7 +5,6 @@ source: "UCLA Law Journal"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Private_Accountability_in_the_age-of_AI.pdf"
 keywords: []
 learnTags: ["bias","business","dataset","ethics","fairness","government","machineLearning"]
 summary: "This article discusses how algorithms based on biased data can result in machine learning that perpetuates inequalities and discrimination, and calls for greater government accountability for AI bias. "

--- a/src/collections/resources/producing-accessible-statistics-diagrams-in-r-pdf-article.md
+++ b/src/collections/resources/producing-accessible-statistics-diagrams-in-r-pdf-article.md
@@ -6,7 +6,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: true
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Producing%20Accessible%20Statistics%20Diagrams%20in%20R.pdf?csf=1&web=1&e=nPpcqO
 keywords:
   - Human-centred computing
   - Accessibility technologies

--- a/src/collections/resources/protecting-privacy-in-an-ai-driven-world-website-article.md
+++ b/src/collections/resources/protecting-privacy-in-an-ai-driven-world-website-article.md
@@ -5,7 +5,6 @@ source: "Brookings"
 readability: ["Intermediate"]
 type: "Website Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Protecting%20privacy%20in%20an%20AI-driven%20world.pdf"
 link: "https://www.brookings.edu/research/protecting-privacy-in-an-ai-driven-world/"
 keywords: []
 learnTags: ["bias","business","dataset","ethics","fairness","framework","government"]

--- a/src/collections/resources/public-policy-course-understanding-and-explaining-bread-mold-on-a-yak.md
+++ b/src/collections/resources/public-policy-course-understanding-and-explaining-bread-mold-on-a-yak.md
@@ -6,7 +6,6 @@ readability:
   - Intermediate
 type: Slide Deck
 openSource: false
-sharePointUrl: https://ocaduniversity.sharepoint.com/:p:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Public%20Policy%20Course%20-%20Understanding%20and%20Explaining%20Bread%20Mold%20on%20a%20Yak.pptx?d=wdb415aaea335477aadf2ddf9b4bf5d32&csf=1&web=1&e=3OA0Si
 learnTags:
   - disability
   - fairness

--- a/src/collections/resources/racial-disparities-in-automated-speech-recognition-pdf-article.md
+++ b/src/collections/resources/racial-disparities-in-automated-speech-recognition-pdf-article.md
@@ -5,7 +5,6 @@ source: "PNAS"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/racial%20disparities%20in%20automated%20speech%20recognition.pdf"
 keywords: []
 learnTags: ["business","methods","ethics","fairness"]
 summary: "Automated speech recognition (ASR) systems are now used in a variety of applications to convert spoken language to text. In this article, a large corpus of sociolinguistic interviews is analyzed, demonstrating large racial disparities in the performance of five popular commercial ASR systems. "

--- a/src/collections/resources/recruitment-ai-has-a-disability-problem-anticipating-and-mitigating-unfair-automated-hiring-decisions.md
+++ b/src/collections/resources/recruitment-ai-has-a-disability-problem-anticipating-and-mitigating-unfair-automated-hiring-decisions.md
@@ -7,7 +7,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: true
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount-OptimizingDiversitywithDisabilityODDChannel/Shared%20Documents/Optimizing%20Diversity%20with%20Disability%20(ODD)%20Channel/Hiring%20Systems/Article%20+%20Resources/Recruitment_AI_%20has%20a%20Disability%20Problem.pdf?csf=1&web=1&e=d6tWag
 link: https://osf.io/preprints/socarxiv/8sxh7/
 keywords:
   - disability

--- a/src/collections/resources/recruitment-ai-has-a-disability-problem-questions-employers-should-be-asking-to-ensure-fairness-in-recruitment.md
+++ b/src/collections/resources/recruitment-ai-has-a-disability-problem-questions-employers-should-be-asking-to-ensure-fairness-in-recruitment.md
@@ -7,7 +7,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: true
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount-OptimizingDiversitywithDisabilityODDChannel/Shared%20Documents/Optimizing%20Diversity%20with%20Disability%20(ODD)%20Channel/Hiring%20Systems/Article%20+%20Resources/Recruitment%20AI%20has%20a%20disability%20Problem.pdf?csf=1&web=1&e=XZsHaH
 link: https://osf.io/preprints/socarxiv/emwn5/
 learnTags:
   - bias

--- a/src/collections/resources/requirements-engineering-for-people-with-cognitive-disabilities-exploring-new-ways-for-peer-researchers-and-developers-to-cooperate-pdf-article.md
+++ b/src/collections/resources/requirements-engineering-for-people-with-cognitive-disabilities-exploring-new-ways-for-peer-researchers-and-developers-to-cooperate-pdf-article.md
@@ -5,7 +5,6 @@ source: "ICCHP 2018 "
 readability: ["Expert"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Requirements%20Engineering%20for%20People%20with%20Cognitive%20Disabilities.pdf"
 keywords: ["Human-machine interaction","R&D","e-Inclusion","Accessibility UCD","Cognitive disabilities"]
 learnTags: ["methods","disability","inclusivePractice"]
 summary: "A research paper that stresses the importance of developing the user experience for new digital technologies through collaboration with their users, who, in this case, are people with cognitive disabilities. "

--- a/src/collections/resources/response-to-office-of-the-privacy-commissioner-of-canada-consultation-proposals-pertaining-to-amendments-to-pipeda-relative-to-artificial-intelligence-pdf-article.md
+++ b/src/collections/resources/response-to-office-of-the-privacy-commissioner-of-canada-consultation-proposals-pertaining-to-amendments-to-pipeda-relative-to-artificial-intelligence-pdf-article.md
@@ -5,7 +5,6 @@ source: "MAIEI"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Response%20to%20Office%20of%20the%20Privacy%20Commissioner%20of%20Canada%20ConsultationProposals%20pertaining%20to%20amendments%20to%20PIPEDA%20relative%20to%20Artificial%20Intelligence.pdf"
 keywords: []
 learnTags: ["bias","ethics","framework","government","solution","trust"]
 summary: "The Montreal AI Ethics Institute's comments and recommendations following their invitation by the Office of the Privacy Commissioner of Canada (OPCC) to provide feedback at a closed roundtable and on the OPCC consultation proposal for AI-related amendments to Canadian privacy legislation. "

--- a/src/collections/resources/reverseengineering-visualizations-recovering-visual-encodings-from-chart-images-pdf-article.md
+++ b/src/collections/resources/reverseengineering-visualizations-recovering-visual-encodings-from-chart-images-pdf-article.md
@@ -7,7 +7,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: true
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Reverse-Engineering%20Visualizations.pdf?csf=1&web=1&e=ZMdt84
 keywords:
   - Create Accessible Content
   - Chart Data Extraction

--- a/src/collections/resources/robots-to-use-new-ai-tool-to-evaluate-all-possibilities-before-making-decisions-website-article.md
+++ b/src/collections/resources/robots-to-use-new-ai-tool-to-evaluate-all-possibilities-before-making-decisions-website-article.md
@@ -5,7 +5,6 @@ source: "EurekAlert!"
 readability: ["Intermediate"]
 type: "Website Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Robots%20to%20use%20new%20AI%20tool%20to%20evaluate%20all%20possibilities%20before%20making%20decisions.pdf"
 link: "https://www.eurekalert.org/pub_releases/2020-04/siot-rtu041420.php"
 keywords: []
 learnTags: ["methods","machineLearning"]

--- a/src/collections/resources/screened-out-onscreen-disability-discrimination-hiring-bias-and-artificial-intelligence-1.md
+++ b/src/collections/resources/screened-out-onscreen-disability-discrimination-hiring-bias-and-artificial-intelligence-1.md
@@ -7,7 +7,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: true
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount-OptimizingDiversitywithDisabilityODDChannel/Shared%20Documents/Optimizing%20Diversity%20with%20Disability%20(ODD)%20Channel/Hiring%20Systems/Article%20+%20Resources/Screened%20out%20Onscreen_%20Disability%20Discrimination%20Hiring%20Bias%20and%20AI.pdf?csf=1&web=1&e=wTTaAP
 link: https://static1.squarespace.com/static/5cb79f7efd6793296c0eb738/t/611c4b5a55f3332cd7257bb2/1629244250721/Vol98_Issue4_Moss_PRINT_FINAL.pdf
 learnTags:
   - bias

--- a/src/collections/resources/semi-supervised-discriminative-classification-robust-to-sample-outliers-and-feature-noises-pdf-article.md
+++ b/src/collections/resources/semi-supervised-discriminative-classification-robust-to-sample-outliers-and-feature-noises-pdf-article.md
@@ -5,7 +5,6 @@ source: "IEEE"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Semi-Supervised%20Discriminative%20Classi%EF%AC%81cation%20Robust%20to%20Sample-Outliers%20and%20Feature-Noises.pdf"
 keywords: ["Linear discriminant analysis","semi-supervised learning","robust classification","feature selection","sample outlier detection","Alzheimer’s disease","Parkinson’s disease","biomarker identification","disease diagnosis","nuclear norm","regularization"]
 learnTags: ["dataset","methods","disability","smallData","solution"]
 summary: "A new approach for discriminative classification in disease diagnosis that is more robust against outliers and noise from this particular type of data.   "

--- a/src/collections/resources/social-data-biases-methodological-pitfalls-and-ethical-boundaries-pdf-article.md
+++ b/src/collections/resources/social-data-biases-methodological-pitfalls-and-ethical-boundaries-pdf-article.md
@@ -5,7 +5,6 @@ source: "Frontiers in Big Data Journal"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Social%20Data-%20Biases,%20Methodological%20Pitfalls,%20and%20Ethical%20Boundaries.pdf"
 keywords: ["social media","user data","biases","evaluation","ethics"]
 learnTags: ["bias","ethics","fairness","framework"]
 summary: "This article highlights data quality issues and general challenges for research using social data, including population biases, behavioural biases, content biases, linking biases, temporal variations and redundancy. "

--- a/src/collections/resources/societyintheloop-programming-the-algorithmic-social-contract-pdf-article.md
+++ b/src/collections/resources/societyintheloop-programming-the-algorithmic-social-contract-pdf-article.md
@@ -5,7 +5,6 @@ source: "Ethics and Information Technology Journal"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Society%20in%20the%20loop%20Programming%20the%20algorithmic%20social%20contract.pdf"
 keywords: ["Ethics ","Artificial intelligence","Society","Governance","Regulation"]
 learnTags: ["ethics","fairness","framework","government","machineLearning"]
 summary: "An article that adds social contract theory to current Human in the Loop (HITL) for monitoring and supervising machine learning systems called Society in the Loop (SITL), where various societal stakeholders are required to monitor the system rather than just the human creator. "

--- a/src/collections/resources/statistical-software-from-a-blind-persons-perspective-pdf-article.md
+++ b/src/collections/resources/statistical-software-from-a-blind-persons-perspective-pdf-article.md
@@ -6,7 +6,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: true
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Statistical%20Software%20from%20a%20Blind%20Person%E2%80%99s%20Perspective.pdf?csf=1&web=1&e=1zLNYh
 link: https://journal.r-project.org/archive/2013-1/godfrey.pdf
 keywords:
   - Create Content

--- a/src/collections/resources/tactile-code-skimmer-a-tool-to-help-blind-programmers-feel-the-structure-of-code-pdf-article.md
+++ b/src/collections/resources/tactile-code-skimmer-a-tool-to-help-blind-programmers-feel-the-structure-of-code-pdf-article.md
@@ -5,7 +5,6 @@ source: "ACM ASSETS 2019"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Tactile%20Code%20Skimmer.pdf?csf=1&web=1&e=yOcVDL"
 keywords: ["Accessibility","Blind Programmers","Code Structure","Tactile Aids","Visually Impaired"]
 learnTags: ["methods","disability","fairness","inclusivePractice","solution"]
 summary: "A paper that introduces the Tactile Code Skimmer, a tool that helps blind and visually impaired programmers skim code. "

--- a/src/collections/resources/technology-developments-in-touch-based-accessible-graphics-a-systematic-review-of-research-2010-2020-pdf-article.md
+++ b/src/collections/resources/technology-developments-in-touch-based-accessible-graphics-a-systematic-review-of-research-2010-2020-pdf-article.md
@@ -5,7 +5,6 @@ source: "CHI 2021"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Technology%20Developments%20in%20Touch-Based%20Accessible%20Graphics.pdf?csf=1&web=1&e=l6bebe"
 link: "https://arxiv.org/pdf/2102.01273.pdf"
 keywords: ["Systematic Literature Review","Assistive Technology","Tactile Graphics","Blind","Low Vision"]
 learnTags: ["disability","inclusivePractice"]

--- a/src/collections/resources/techshops-engaging-young-adults-with-intellectual-disability-in-exploratory-design-research-pdf-article.md
+++ b/src/collections/resources/techshops-engaging-young-adults-with-intellectual-disability-in-exploratory-design-research-pdf-article.md
@@ -5,7 +5,6 @@ source: "CHI 2019"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/%E2%80%9CTechShops%E2%80%9D_Engaging%20Young%20Adults%20with%20Intellectual%20Disability%20in%20Exploratory%20Design%20Research.pdf"
 keywords: ["“TechShops,” contextual interviews","intellectual disability","engagement","co-design workshops"]
 learnTags: ["disability","framework","machineLearning","solution"]
 summary: "A workshop-based case study that explores how young adults with intellectual disabilities use social media and how their activities can be supported through co-design. "

--- a/src/collections/resources/ten-simple-rules-for-responsible-big-data-research-pdf-article.md
+++ b/src/collections/resources/ten-simple-rules-for-responsible-big-data-research-pdf-article.md
@@ -5,7 +5,6 @@ source: "PLOS Computational Biology Journal"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Ten%20Simple%20Rules%20for%20Responsible%20Big%20Data%20Research.pdf"
 keywords: []
 learnTags: ["ethics","framework"]
 summary: "A paper that stresses that big data research engages with human subjects, so researchers have the ethical responsibility to minimize potential harm. "

--- a/src/collections/resources/the-ai-ethics-review-eight-sticking-points-we-havent-resolved-website-article.md
+++ b/src/collections/resources/the-ai-ethics-review-eight-sticking-points-we-havent-resolved-website-article.md
@@ -5,7 +5,6 @@ source: "Diginomia"
 readability: ["Beginner"]
 type: "Website Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/The%20AI%20ethics%20review%20-%20eight%20sticking%20points%20we%20haven%27t%20resolved.pdf"
 link: "https://diginomica.com/ai-ethics-review-eight-sticking-points-we-havent-resolved"
 keywords: []
 learnTags: ["basicAI","ethics","fairness","framework"]

--- a/src/collections/resources/the-ai-pandorica-linking-ethically-challenged-technical-outputs-to-prospective-policy-approaches-pdf-article.md
+++ b/src/collections/resources/the-ai-pandorica-linking-ethically-challenged-technical-outputs-to-prospective-policy-approaches-pdf-article.md
@@ -5,7 +5,6 @@ source: "dg.o 2019"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/The%20A.I.%20Pandorica%20_Linking%20Ethically%20Challenged%20Technical%20Outputs%20to%20Prospective%20Policy%20Approaches.pdf"
 keywords: ["Artificial intelligence","ethics","machine learning","algorithmic bias","digital government"]
 learnTags: ["bias","ethics","fairness","framework","machineLearning"]
 summary: "An overview of AI issues and possible methods for addressing bias, including AI audits, implementing accountability in policy, instituting Code of Ethics for AI practitioners, data transparency, diversity in the field, and ethics in higher education. "

--- a/src/collections/resources/the-algorithm-audit-scoring-the-algorithms-that-score-us-pdf-article.md
+++ b/src/collections/resources/the-algorithm-audit-scoring-the-algorithms-that-score-us-pdf-article.md
@@ -5,7 +5,6 @@ source: "Big Data and Society"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/The%20Algorithm%20Audit.pdf?csf=1&web=1&e=sAFVQV"
 keywords: ["Algorithm audits","algorithm ethics","ethics","ethics of AI","machine learning","machine learning and ethics"]
 learnTags: ["methods","ethics","fairness","framework","solution"]
 summary: "An article that proposes an auditing framework to guide the ethical assessment of an algorithm.  "

--- a/src/collections/resources/the-cost-of-poverty-a-different-way-of-conceiving-of-poverty.md
+++ b/src/collections/resources/the-cost-of-poverty-a-different-way-of-conceiving-of-poverty.md
@@ -6,7 +6,6 @@ readability:
   - Intermediate
 type: Slide Deck
 openSource: false
-sharePointUrl: https://ocaduniversity.sharepoint.com/:p:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/The%20Cost%20of%20Poverty%20-%20A%20Different%20Way%20of%20Conceiving%20of%20Poverty.pptx?d=wb42626a3af4a441b9e8ee2ac807233fd&csf=1&web=1&e=ZWYHTg
 learnTags:
   - disability
   - fairness

--- a/src/collections/resources/the-current-state-of-industrial-practice-in-artificial-intelligence-ethics-pdf-article.md
+++ b/src/collections/resources/the-current-state-of-industrial-practice-in-artificial-intelligence-ethics-pdf-article.md
@@ -5,7 +5,6 @@ source: "IEEE"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/The%20current%20State%20of%20Industrial%20Practise%20in%20AI%20Ethics.pdf"
 link: "https://jyx.jyu.fi/bitstream/handle/123456789/68453/vakkuriym.pdf?sequence=2&isAllowed=y"
 keywords: ["Artificial Intelligence","Ethics","Software Development"]
 learnTags: ["bias","ethics","fairness","framework"]

--- a/src/collections/resources/the-disparate-effects-of-strategic-manipulation-pdf-article.md
+++ b/src/collections/resources/the-disparate-effects-of-strategic-manipulation-pdf-article.md
@@ -5,7 +5,6 @@ source: "FAT 2019"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/The%20Disparate%20Effects%20of%20Strategic%20Manipulation.pdf"
 keywords: []
 learnTags: ["methods","fairness","machineLearning"]
 summary: "An article that shows how classification models in machine learning can reinforce existing inequalities and how attempts to intervene in the learning model to correct this response can lead to further social adversity. "

--- a/src/collections/resources/the-externalities-of-exploration-and-how-data-diversity-helps-exploitation-pdf-article.md
+++ b/src/collections/resources/the-externalities-of-exploration-and-how-data-diversity-helps-exploitation-pdf-article.md
@@ -5,7 +5,6 @@ source: "COLT 2018"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/The%20Externalities%20of%20Exploration%20and%20How%20Data%20Diversity%20Helps%20Exploitation.pdf"
 keywords: []
 learnTags: ["dataset","methods","ethics","fairness","machineLearning"]
 summary: "Online learning algorithms must balance exploration and exploitation, but recently, concerns have been raised about whether the process of exploration could be viewed as unfair, placing too much burden on certain individuals or groups. Motivated by these concerns, the externalities of exploration are studied, and the notion of a group externality is introduced, measuring the extent to which the presence of a majority group of users impacts the rewards of a minority group.  "

--- a/src/collections/resources/the-impact-of-ableism-on-disability-discrimination-in-employment.md
+++ b/src/collections/resources/the-impact-of-ableism-on-disability-discrimination-in-employment.md
@@ -6,7 +6,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: true
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount-OptimizingDiversitywithDisabilityODDChannel/Shared%20Documents/Optimizing%20Diversity%20with%20Disability%20(ODD)%20Channel/Hiring%20Systems/Article%20+%20Resources/The%20Impact%20of%20Ableism%20on%20Disability%20Discrimination%20in%20Employment.pdf?csf=1&web=1&e=mf7RrT
 link: https://digitalcommons.sacredheart.edu/cgi/viewcontent.cgi?article=1704&context=acadfest
 learnTags:
   - bias

--- a/src/collections/resources/the-legal-and-ethical-implications-of-using-ai-in-hiring.md
+++ b/src/collections/resources/the-legal-and-ethical-implications-of-using-ai-in-hiring.md
@@ -6,7 +6,6 @@ readability:
   - Intermediate
 type: PDF Article
 openSource: true
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount-OptimizingDiversitywithDisabilityODDChannel/Shared%20Documents/Optimizing%20Diversity%20with%20Disability%20(ODD)%20Channel/Hiring%20Systems/Article%20+%20Resources/The-legal-and-ethical-implications-of-using-AI-in-Hiring.pdf?csf=1&web=1&e=crqmNM
 link: https://egn.com/dk/wp-content/uploads/sites/3/2020/06/The-legal-and-ethical-implications-of-using-AI-in-Hiring.pdf
 learnTags:
   - business

--- a/src/collections/resources/the-relationship-between-trust-in-ai-and-trustworthy-machine-learning-technologies-pdf-article.md
+++ b/src/collections/resources/the-relationship-between-trust-in-ai-and-trustworthy-machine-learning-technologies-pdf-article.md
@@ -7,7 +7,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: false
-sharePointUrl: https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/The%20relationship%20between%20trust%20in%20AI%20and%20trustworthy%20machine%20learning%20technologies.pdf
 keywords:
   - trust
   - trustworthiness

--- a/src/collections/resources/the-short-anthropological-guide-to-the-study-of-ethical-ai-pdf-article.md
+++ b/src/collections/resources/the-short-anthropological-guide-to-the-study-of-ethical-ai-pdf-article.md
@@ -5,7 +5,6 @@ source: "MAIEI"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/The%20Short%20Anthropological%20Guide%20to%20Ethical%20AI.pdf?csf=1&web=1&e=dXYXXg"
 keywords: []
 learnTags: ["bias","ethics","fairness","researchCentre","trust"]
 summary: "A guide that provides an introduction to AI ethics and social science and anthropological perspectives on the development of AI. "

--- a/src/collections/resources/the-social-dilemma-in-artificial-intelligence-development-and-why-we-have-to-solve-it.md
+++ b/src/collections/resources/the-social-dilemma-in-artificial-intelligence-development-and-why-we-have-to-solve-it.md
@@ -7,7 +7,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: false
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/The%20Social%20Dilemma%20in%20Artificial%20Intelligence.pdf?csf=1&web=1&e=hxwwov
 link: https://link.springer.com/content/pdf/10.1007/s43681-021-00120-w.pdf
 keywords:
   - Artificial intelligence

--- a/src/collections/resources/the-state-of-ai-ethics-report-april-2021-pdf-article.md
+++ b/src/collections/resources/the-state-of-ai-ethics-report-april-2021-pdf-article.md
@@ -5,7 +5,6 @@ source: "MAIEI"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/State%20of%20AI%20Ethics%20Report%20April%202021.pdf?csf=1&web=1&e=b1g4ES"
 link: "https://montrealethics.ai/wp-content/uploads/2021/04/SAIER-Apr2021-Final.pdf"
 keywords: []
 learnTags: ["bias","ethics","fairness"]

--- a/src/collections/resources/the-state-of-ai-ethics-report-january-2021-pdf-article.md
+++ b/src/collections/resources/the-state-of-ai-ethics-report-january-2021-pdf-article.md
@@ -5,7 +5,6 @@ source: "MAIEI"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/The-State-of-AI-Ethics-Report-January-2021.pdf?csf=1&web=1&e=lVWGDW"
 link: "https://montrealethics.ai/wp-content/uploads/2021/01/The-State-of-AI-Ethics-Report-January-2021.pdf"
 keywords: []
 learnTags: ["bias","ethics","fairness","researchCentre","trust"]

--- a/src/collections/resources/the-state-of-ai-ethics-report-june-2020-pdf-article.md
+++ b/src/collections/resources/the-state-of-ai-ethics-report-june-2020-pdf-article.md
@@ -5,7 +5,6 @@ source: "MAIEI"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/The-State-of-AI-Ethics-Report-June-2020.pdf?csf=1&web=1&e=2wAvHs"
 link: "https://montrealethics.ai/wp-content/uploads/2020/06/State-of-AI-Ethics-June-2020-report.pdf"
 keywords: []
 learnTags: ["bias","ethics","fairness","researchCentre","trust"]

--- a/src/collections/resources/the-state-of-ai-ethics-report-october-2020-pdf-article.md
+++ b/src/collections/resources/the-state-of-ai-ethics-report-october-2020-pdf-article.md
@@ -5,7 +5,6 @@ source: "MAIEI"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/The-State-of-AI-Ethics-Report-Oct-2020.pdf?csf=1&web=1&e=hMjwhv"
 link: "https://montrealethics.ai/wp-content/uploads/2020/10/State-of-AI-Ethics-Oct-2020.pdf"
 keywords: []
 learnTags: ["bias","ethics","fairness","researchCentre","trust"]

--- a/src/collections/resources/there-is-hope-after-all-quantifying-opinion-and-trustworthiness-in-neural-networks-pdf-article.md
+++ b/src/collections/resources/there-is-hope-after-all-quantifying-opinion-and-trustworthiness-in-neural-networks-pdf-article.md
@@ -5,7 +5,6 @@ source: "Frontiers in Artificial Intelligence Journal"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/There%20Is%20Hope%20After%20All.pdf"
 keywords: ["artificial intelligence","deep neural networks","machine learning","trust in AI","subjective logic"]
 learnTags: ["dataTools","ethics","framework","machineLearning","trust"]
 summary: "An article that introduces DeepTrust, a new subjective logic framework that determines the trustworthiness of both data sets and their associated AI algorithms. "

--- a/src/collections/resources/this-is-how-ai-bias-really-happens-and-why-its-so-hard-to-fix-website-article.md
+++ b/src/collections/resources/this-is-how-ai-bias-really-happens-and-why-its-so-hard-to-fix-website-article.md
@@ -5,7 +5,6 @@ source: "MIT Technology Review"
 readability: ["Intermediate"]
 type: "Website Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/This%20is%20how%20AI%20bias%20really%20happens%20and%20and%20why%20it%E2%80%99s%20so%20hard%20to%20fix.pdf"
 link: "https://www.technologyreview.com/2019/02/04/137602/this-is-how-ai-bias-really-happensand-why-its-so-hard-to-fix/"
 keywords: []
 learnTags: ["basicAI","bias","fairness"]

--- a/src/collections/resources/toward-accountable-discrimination-aware-data-mining-the-importance-of-keeping-the-human-in-the-loop-and-under-the-looking-glass-pdf-article.md
+++ b/src/collections/resources/toward-accountable-discrimination-aware-data-mining-the-importance-of-keeping-the-human-in-the-loop-and-under-the-looking-glass-pdf-article.md
@@ -5,7 +5,6 @@ source: "Big Data"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Toward%20Accountable%20Discrimination-Aware%20Data%20Mining_The%20Importance%20of%20Keeping%20the%20Human%20in%20the%20Loop-and%20Under%20the%20Looking%20Glass.pdf"
 keywords: ["Discrimination discovery and prevention","Discrimination-aware and fairness-aware data mining","Accountability","Data protection","Evaluation","User studies"]
 learnTags: ["bias","methods","ethics","fairness"]
 summary: "This paper further discusses discrimination-aware data mining practices and the role of humans in (semi-) automated decision making to support accountable data processing design strategies that support reflection and avoid unconscious bias. "

--- a/src/collections/resources/toward-an-understanding-of-responsible-artificial-intelligence-practices-pdf-article.md
+++ b/src/collections/resources/toward-an-understanding-of-responsible-artificial-intelligence-practices-pdf-article.md
@@ -5,7 +5,6 @@ source: "HICSS 2020"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Toward%20an%20Understanding%20of%20Responsible%20Artificial%20Intelligence%20Practices.pdf"
 link: "https://www.researchgate.net/publication/336149427_Toward_an_Understanding_of_Responsible_Artificial_Intelligence_Practices"
 keywords: []
 learnTags: ["bias","ethics","fairness","framework","inclusivePractice","solution"]

--- a/src/collections/resources/toward-fairness-in-ai-for-people-with-disabilities-a-research-roadmap-pdf-article.md
+++ b/src/collections/resources/toward-fairness-in-ai-for-people-with-disabilities-a-research-roadmap-pdf-article.md
@@ -5,7 +5,6 @@ source: "ACM ASSETS 2019 "
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Toward%20Fairness%20in%20AI%20for%20People%20with%20Disabilities-%20%20A%20Research%20Roadmap%20.pdf"
 keywords: ["Artificial intelligence","machine learning","data","disability","accessibility","inclusion","AI fairness","AI bias","ethical AI."]
 learnTags: ["ethics","fairness"]
 summary: "Identifies how several AI technologies, such as automated speech recognition tools and language prediction algorithms, may not be useful for persons with disabilities and may discriminate against them. "

--- a/src/collections/resources/toward-proactive-social-inclusion-powered-by-machine-learning-pdf-article.md
+++ b/src/collections/resources/toward-proactive-social-inclusion-powered-by-machine-learning-pdf-article.md
@@ -5,7 +5,6 @@ source: "Knowledge and Information Systems Journal"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Toward%20proactive%20social%20inclusion%20powered%20by%20machine%20learning.pdf"
 keywords: ["social exclusion","social services","data analysis","machine learning","data mining"]
 learnTags: ["dataset","dataTools","methods","inclusivePractice","machineLearning"]
 summary: "A new prediction model for social workers for identifying individuals who are at risk of social exclusion. "

--- a/src/collections/resources/toward-situated-interventions-for-algorithmic-equity-lessons-from-the-field-pdf-article.md
+++ b/src/collections/resources/toward-situated-interventions-for-algorithmic-equity-lessons-from-the-field-pdf-article.md
@@ -5,7 +5,6 @@ source: "FAT 2020"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Toward%20Situated%20Interventions%20for%20Algorithmic%20Equity-Lessons%20from%20the%20Field.pdf"
 keywords: []
 learnTags: ["bias","methods","ethics","fairness","framework","inclusivePractice"]
 summary: "This paper explores  the development of the Algorithmic Equity Toolkit for the practice of situated investigations into fairness, accountability and transparency in algorithmic systems.  "

--- a/src/collections/resources/toward-trustworthy-ai-development-mechanisms-for-supporting-verifiable-claims-pdf-article.md
+++ b/src/collections/resources/toward-trustworthy-ai-development-mechanisms-for-supporting-verifiable-claims-pdf-article.md
@@ -5,7 +5,6 @@ source: "arXiv"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Toward%20Trustworthy%20AI%20Development_Mechanisms%20for%20Supporting%20Verifiable%20Claims.pdf"
 keywords: ["AI","AI system","AI development","AI developer","responsible AI development","transparency","trust","trustworthiness"]
 learnTags: ["bias","methods","ethics","fairness","framework","trust"]
 summary: "A richer toolbox of mechanisms for AI development can inform developers’ efforts to earn trust, the demands made of AI developers by activists and civil society organizations, and regulators’ efforts to ensure that AI is developed responsibly. "

--- a/src/collections/resources/tracking-stemxcomet-teaching-programming-to-blind-students-via-3d-printing-crisis-management-and-twitter-pdf-article.md
+++ b/src/collections/resources/tracking-stemxcomet-teaching-programming-to-blind-students-via-3d-printing-crisis-management-and-twitter-pdf-article.md
@@ -7,7 +7,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: true
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Tracking%20@stemxcomet%20Teaching%20Programming%20to%20Blind%20Students%20via%203D%20Printing,%20Crisis%20Management,%20and%20Twitter.pdf?csf=1&web=1&e=jzsNwG
 keywords:
   - Education
   - programming

--- a/src/collections/resources/translation-tracks-and-data-an-algorithmic-bias-effort-in-practice-pdf-article.md
+++ b/src/collections/resources/translation-tracks-and-data-an-algorithmic-bias-effort-in-practice-pdf-article.md
@@ -5,7 +5,6 @@ source: "CHI 2019"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Translation,%20Tracks%20&%20Data_an%20Algorithmic%20Bias%20Effort%20in%20Practice.pdf"
 keywords: ["Algorithmic bias","algorithmic accountability","bias and data checklist","industry practice"]
 learnTags: ["bias","dataset","framework","machineLearning"]
 summary: "A case study on lessons on addressing algorithmic bias, including the development of a bias checklist and dashboarding and data efforts for auditing. "

--- a/src/collections/resources/trust-and-bias-in-robots-these-elements-of-artificial-intelligence-present-ethical-challenges-which-scientists-are-trying-to-solve-pdf-article.md
+++ b/src/collections/resources/trust-and-bias-in-robots-these-elements-of-artificial-intelligence-present-ethical-challenges-which-scientists-are-trying-to-solve-pdf-article.md
@@ -5,7 +5,6 @@ source: "American Scientist"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Trust_and_Bias_in_Robots_These.pdf"
 keywords: []
 learnTags: ["bias","methods","ethics","machineLearning","trust"]
 summary: "A discussion of how the use of biased AI in healthcare and self-driving cars can lead to problematic decision-making that is compounded by the human tendency to trust AI decisions. "

--- a/src/collections/resources/trustworthy-ai-is-a-framework-to-help-manage-unique-risk-website-article.md
+++ b/src/collections/resources/trustworthy-ai-is-a-framework-to-help-manage-unique-risk-website-article.md
@@ -5,7 +5,6 @@ source: "Deloitte AI Institute"
 readability: ["Intermediate"]
 type: "Website Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/%E2%80%98Trustworthy%20AI%E2%80%99%20is%20a%20framework%20to%20help...ge%20unique%20risk%20-%20MIT%20Technology%20Review.pdf"
 link: "https://www.technologyreview.com/s/615400/trustworthy-ai-is-a-framework-to-help-manage-unique-risk/"
 keywords: []
 learnTags: ["business","methods","ethics","fairness","framework","government","trust"]

--- a/src/collections/resources/turning-brain-activity-to-text-with-ai-time-for-nations-to-debate-what-is-ethical-and-what-isnt-website-article.md
+++ b/src/collections/resources/turning-brain-activity-to-text-with-ai-time-for-nations-to-debate-what-is-ethical-and-what-isnt-website-article.md
@@ -5,7 +5,6 @@ source: "Financial Express"
 readability: ["Intermediate"]
 type: "Website Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Turning%20brain%20activity%20to%20text%20with%20AI-...and%20what%20isn%E2%80%99t%20-%20The%20Financial%20Express.pdf"
 link: "https://www.financialexpress.com/opinion/turning-brain-activity-to-text-with-ai-time-for-nations-to-debate-what-is-ethical-and-what-isnt/1918479/"
 keywords: []
 learnTags: ["disability","ethics","fairness","government"]

--- a/src/collections/resources/understanding-data-accessibility-for-people-with-intellectual-and-developmental-disabilities.md
+++ b/src/collections/resources/understanding-data-accessibility-for-people-with-intellectual-and-developmental-disabilities.md
@@ -7,7 +7,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: false
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Understanding%20Data%20Accessibility%20for%20People%20with%20Intellectual%20and%20Developmental%20Disabilities.pdf?csf=1&web=1&e=5ffA5c
 link: ""
 keywords:
   - human-subjects quantitative studies

--- a/src/collections/resources/understanding-the-effect-of-accuracy-on-trust-in-machine-learning-models-pdf-article.md
+++ b/src/collections/resources/understanding-the-effect-of-accuracy-on-trust-in-machine-learning-models-pdf-article.md
@@ -5,7 +5,6 @@ source: "CHI 2019"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Understanding%20the%20Effect%20of%20Accuracy%20on%20Trust%20in%20Machine%20Learning%20Models.pdf"
 keywords: ["Machine learning","trust","human-subject experiments"]
 learnTags: ["methods","machineLearning","solution","trust"]
 summary: "An article that explores how a randomized human subject experiment found the average person's trust in a machine learning model is affected by the model's stated accuracy level and observation of the model in practice.  "

--- a/src/collections/resources/understanding-the-telework-experience-of-people-with-disabilities-pdf-article.md
+++ b/src/collections/resources/understanding-the-telework-experience-of-people-with-disabilities-pdf-article.md
@@ -5,7 +5,6 @@ source: "ACM"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Understanding%20the%20Telework%20Experience%20of%20People%20with%20Disabilities.pdf?csf=1&web=1&e=Vvbudk"
 keywords: ["Telework","computer-mediated communication","collaboration technology","video calling","people with disabilities"]
 learnTags: ["bias","disability","ethics","fairness"]
 summary: "Twenty-five persons with disabilities were interviewed during the first month of the COVID-19 pandemic response to understand how the sudden shift to pervasive teleworking affected their telework experience. "

--- a/src/collections/resources/unintended-machine-learning-biases-as-social-barriers-for-persons-with-disabilities-pdf-article.md
+++ b/src/collections/resources/unintended-machine-learning-biases-as-social-barriers-for-persons-with-disabilities-pdf-article.md
@@ -5,7 +5,6 @@ source: "CHI 2016"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Unintended%20machine%20learning%20biases%20as%20social%20barriers%20for%20persons%20with%20disabilities.pdf"
 keywords: []
 learnTags: ["bias","disability","fairness","machineLearning"]
 summary: "A research paper about barriers and issues of fairness faced by persons with disabilities due to the social biases present in machine learning natural language processing models.  "

--- a/src/collections/resources/visualizing-for-the-nonvisual-enabling-the-visually-impaired-to-use-visualization-pdf-article.md
+++ b/src/collections/resources/visualizing-for-the-nonvisual-enabling-the-visually-impaired-to-use-visualization-pdf-article.md
@@ -7,7 +7,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: true
-sharePointUrl: https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Visualizing%20for%20the%20Non-Visual.pdf?csf=1&web=1&e=0PEfIh
 keywords:
   - Human-centred computing
   - Visual analytics

--- a/src/collections/resources/vr-disability-simulation-reduces-implicit-bias-towards-persons-with-disabilities-pdf-article.md
+++ b/src/collections/resources/vr-disability-simulation-reduces-implicit-bias-towards-persons-with-disabilities-pdf-article.md
@@ -5,7 +5,6 @@ source: "IEEE"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/VR%20Disability%20Simulation%20Reduces%20Implicit%20Bias%20Towards%20Persons%20with%20Disabilities.pdf"
 keywords: ["Virtual Reality","Implicit Association Test","IAT","Bias","Disability Simulation","Immersion","Presence","Learning","InformationRecall","Head-Mounted Display","HMD"]
 learnTags: ["bias","methods","disability"]
 summary: "A paper that examines how Virtual Reality Disability Simulations can impact a person's information recall and implicit association toward people with disabilities. "

--- a/src/collections/resources/webuildai-participatory-framework-for-algorithmic-governance-pdf-article.md
+++ b/src/collections/resources/webuildai-participatory-framework-for-algorithmic-governance-pdf-article.md
@@ -5,7 +5,6 @@ source: "CSCW 2019"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/WeBuildAI_Participatory%20Framework%20for%20Algorithmic%20Governance.pdf"
 keywords: ["participatory algorithm design","collective participation","human-centered AI","matching algorithm","algorithmic fairness"]
 learnTags: ["basicAI","methods","ethics","fairness","framework"]
 summary: "The WeBuildAI team designed, applied and evaluated this social participatory framework for engaging community stakeholders to enable people to create a decision-making algorithm that fits their needs. "

--- a/src/collections/resources/what-are-important-ethical-implications-of-using-facial-recognition-technology-in-health-care-website-article.md
+++ b/src/collections/resources/what-are-important-ethical-implications-of-using-facial-recognition-technology-in-health-care-website-article.md
@@ -5,7 +5,6 @@ source: "AMA Journal of Ethics"
 readability: ["Intermediate"]
 type: "Website Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/What%20are%20important%20ethical%20implications%20of%20using%20facial%20recognition%20technology%20in%20health%20care.pdf"
 link: "https://journalofethics.ama-assn.org/article/what-are-important-ethical-implications-using-facial-recognition-technology-health-care/2019-02"
 keywords: []
 learnTags: ["dataTools","methods","disability","ethics","fairness","government"]

--- a/src/collections/resources/what-does-it-mean-to-solve-the-problem-of-discrimination-inhiring-social-technical-and-legal-perspectives-from-the-uk-on-automated-hiring-systems-pdf-article.md
+++ b/src/collections/resources/what-does-it-mean-to-solve-the-problem-of-discrimination-inhiring-social-technical-and-legal-perspectives-from-the-uk-on-automated-hiring-systems-pdf-article.md
@@ -5,7 +5,6 @@ source: "FAT 2020"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/What%20does%20it%20mean%20to%E2%80%98solve%20the%20problem%20of%20discrimination%20in%20hiring.pdf"
 keywords: ["Socio-technical systems","automated hiring","algorithmic decisionmaking","fairness","discrimination","GDPR","social justice"]
 learnTags: ["dataTools","methods","ethics","fairness","machineLearning"]
 summary: "The paper outlines how data-driven technologies are transforming hiring practices and focuses on three automated hiring systems (AHSs) widely in use in the UK claim to deal with bias. "

--- a/src/collections/resources/what-is-facial-recognition-technology-pdf-article.md
+++ b/src/collections/resources/what-is-facial-recognition-technology-pdf-article.md
@@ -5,7 +5,6 @@ source: "Algorithmic Justice League"
 readability: ["Beginner"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/What%20Is%20Facial%20Recognition%20Technology%20-%20AJL.pdf"
 link: "https://www.ajl.org/facial-recognition-technology"
 keywords: []
 learnTags: ["basicAI","bias","business","dataTools","ethics","government","machineLearning","notForProfit"]

--- a/src/collections/resources/what-is-responsible-and-sustainable-data-science-pdf-article.md
+++ b/src/collections/resources/what-is-responsible-and-sustainable-data-science-pdf-article.md
@@ -5,7 +5,6 @@ source: "Big Data and Society"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/What%20is%20responsible%20and%20sustainable%20data%20science.pdf"
 keywords: ["Commons","health","responsibility","ethics","privacy","data protection"]
 learnTags: ["ethics","fairness","framework","government"]
 summary: "This article argues that a commons analytical framework is one approach to determining what makes data science responsible or sustainable, since it offers useful signposts for how to establish governance principles for shared resources. "

--- a/src/collections/resources/what-is-the-point-of-fairness-disability-ai-and-the-complexity-of-justice-pdf-article.md
+++ b/src/collections/resources/what-is-the-point-of-fairness-disability-ai-and-the-complexity-of-justice-pdf-article.md
@@ -5,7 +5,6 @@ source: "SIGACCESS"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/What%20is%20the%20point%20of%20fairness_disability,%20AI%20and%20the%20complexity%20of%20justice.pdf"
 link: "https://arxiv.org/abs/1908.01024"
 keywords: ["Computer Vision","Disability","AI","fairness","justice"]
 learnTags: ["disability","ethics","fairness"]

--- a/src/collections/resources/what-makes-us-human-makes-us-also-ai-irresponsible-when-and-how-to-inject-your-ai-with-r-pdf-article.md
+++ b/src/collections/resources/what-makes-us-human-makes-us-also-ai-irresponsible-when-and-how-to-inject-your-ai-with-r-pdf-article.md
@@ -5,7 +5,6 @@ source: "World Summit AI 2019"
 readability: ["Intermediate"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/What%20Makes%20Us%20Human%20Makes%20Us%20Also%20AI%20(ir)Responsible.pdf"
 link: "https://cdn2.hubspot.net/hubfs/4149027/WSAI19/Speaker%20presentations/Monett_WorldSummitAI_2019%201515.pdf"
 keywords: []
 learnTags: ["bias","methods","ethics","fairness","trust"]

--- a/src/collections/resources/whats-in-a-name-reducing-bias-in-bios-without-access-to-protected-attributes-pdf-article.md
+++ b/src/collections/resources/whats-in-a-name-reducing-bias-in-bios-without-access-to-protected-attributes-pdf-article.md
@@ -5,7 +5,6 @@ source: "NAACL 2019"
 readability: ["Expert"]
 type: "PDF Article"
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/What%20is%20in%20a%20Name_%20Reducing%20Bias%20in%20Bios%20without%20Access%20to%20Protected%20Attributes.pdf"
 keywords: []
 learnTags: ["bias","dataTools","methods","ethics","fairness","framework","inclusivePractice","machineLearning","solution"]
 summary: "This article proposes a method for reducing bias in machine learning classifiers without relying on protected attributes. In the context of occupation classification, this method discourages a classifier from learning a correlation between the predicted probability of an individual’s occupation and a word embedding of their name.  "

--- a/src/collections/resources/when-the-machine-meets-the-expert-an-ethnography-of-developing-ai-for-hiring.md
+++ b/src/collections/resources/when-the-machine-meets-the-expert-an-ethnography-of-developing-ai-for-hiring.md
@@ -6,7 +6,6 @@ readability:
   - Expert
 type: PDF Article
 openSource: false
-sharePointUrl: "https://ocaduniversity.sharepoint.com/:b:/r/teams/Team_WeCount-\
   OptimizingDiversitywithDisabilityODDChannel/Shared%20Documents/Optimizing%20D\
   iversity%20with%20Disability%20(ODD)%20Channel/Hiring%20Systems/Article%20+%2\
   0Resources/WHEN%20THE%20MACHINE%20MEETS%20THE%20EXPERT_AN%20ETHNOGRAPHY%20OF%\

--- a/src/collections/resources/working-to-address-algorithmic-bias-dont-overlook-the-role-of-demographic-data-website-article.md
+++ b/src/collections/resources/working-to-address-algorithmic-bias-dont-overlook-the-role-of-demographic-data-website-article.md
@@ -5,7 +5,6 @@ source: "AI&."
 readability: ["Intermediate"]
 type: "Website Article"
 openSource: true
-sharePointUrl: "https://ocaduniversity.sharepoint.com/teams/Team_WeCount/Shared%20Documents/Resources%20and%20Tools/Literature%20(curated)/Working%20to%20Address%20Algorithmic%20Bias%20Don%E2%80%99t%20Overlook%20the%20Role%20of%20Demographic%20Data.pdf"
 link: "https://medium.com/@PartnershipAI/working-to-address-algorithmic-bias-dont-overlook-the-role-of-demographic-data-e71c304ee742"
 keywords: []
 learnTags: ["bias","methods","ethics","framework"]

--- a/src/resourcesIndex.njk
+++ b/src/resourcesIndex.njk
@@ -27,7 +27,6 @@ permalink: resourceData.json
         {{ tag | dump | safe }}{% if not loop.last %},{% endif %}
         {%- endfor -%}
       ],
-      "sharePointUrl": {% if item.data.sharePointUrl -%} {{- item.data.sharePointUrl | dump | safe -}} {%- else -%} "" {%- endif %},
       "source": {{ item.data.source | dump | safe }},
       "summary": {% if item.data.summary -%} {{- item.data.summary | dump | safe -}} {%- else -%} "" {%- endif %},
       "abstract": {{ item.template.frontMatter.content | replace("\n", "") | dump | safe }}


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Remove SharePoint field from resources, as it is not accessible to public.

## Steps to test

### check on the public page

1. Go to resources page
2. Find a resource that had sharepoint url field before; example resource title "Accessible Computer Science for K-12 Students with Disabilities"
3. Check that there's no SharePoint URL field

### check on the admin interface

1. Go to Admin page
2. Create a new resource
3. Check that there's no SharePoint field
