### PR TITLE
chore: run lint action when NPM dependencies change

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,12 +3,16 @@ name: Lint assets
 on:
   push:
     paths:
+      - 'package.json'
+      - 'package-lock.json'
       - '**.js'
       - '**.md'
       - '**.scss'
       - '!src/collections/**.md'
   pull_request:
     paths:
+      - 'package.json'
+      - 'package-lock.json'
       - '**.js'
       - '**.md'
       - '**.scss'


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Right now the lint GitHub Action only runs when lintable files (JS, MD, SCSS) are modified. This PR will also trigger the lint action when the package.json and/or package-lock.json files change so that we can better assess the impact of, say, a Dependabot update to Stylelint.

## Steps to test

Not applicable; the GitHub Action which lints files will now run on PRs like https://github.com/inclusive-design/wecount.inclusivedesign.ca/pull/1402.

## Additional information

Not applicable.

## Related issues

Not applicable.