### PR TITLE
fix: resolve Node 18 build issue with covid-data-monitor

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "private": true,
   "scripts": {
     "build": "npm-run-all clean -s build:*",
-    "build:mapDependency": "npm explore covid-data-monitor -- npm run build:noInfusion",
+    "build:mapDependency": "npm explore covid-data-monitor -- npm install fs-extra && npm explore covid-data-monitor -- npm run build:noInfusion",
     "build:eleventy": "node --max-old-space-size=6000 ./node_modules/@11ty/eleventy/cmd.js",
     "build:netlify-cms": "node ./build-cms.js",
     "clean": "rimraf dist",


### PR DESCRIPTION
* [ ] This pull request has been linted by running `npm run lint` without errors
* [ ] This pull request has been tested by running `npm run start` and reviewing affected routes
* [ ] This pull request has been built by running `npm run build` without errors
* [ ] This isn't a duplicate of an existing pull request

## Description

`fs-extra` is used in the inclusive-design/covid-data-monitor build script, but it's not a dependency, but rather a devDependency of `covid-data-monitor`. This means that the builds fail on Node 18, I think because of the way dependencies of dependencies are handled. This PR adds a (minimal) fix by running `npm install fs-extra` within the `covid-data-monitor` dependency before trying to build it.

## Steps to test

1. `npm ci`
2. `npm run build`

**Expected behavior:** Build succeeds.

## Additional information

Not applicable.

## Related issues

Not applicable.