### PR TITLE
fix: vertical alignment issues for Image and Text widget

### DIFF
--- a/src/scss/layout/_layout.scss
+++ b/src/scss/layout/_layout.scss
@@ -58,16 +58,37 @@ article {
 }
 
 // WP styles for vertically aligning text within Media & Text blocks
-.image-and-text--vertical-top .image-and-text__content {
-	align-self: start;
+.image-and-text--vertical-top {
+	.image-and-text__media,
+	.image-and-text__content {
+		align-self: start;
+
+		& > * {
+			margin-block: 0;
+		}
+	}
 }
 
-.image-and-text--vertical-center .image-and-text__content {
-	align-self: center;
+.image-and-text--vertical-center {
+	.image-and-text__media,
+	.image-and-text__content {
+		align-self: center;
+
+		& > * {
+			margin-block: 0;
+		}
+	}
 }
 
-.image-and-text--vertical-bottom .image-and-text__content {
-	align-self: end;
+.image-and-text--vertical-bottom {
+	.image-and-text__media,
+	.image-and-text__content {
+		align-self: end;
+
+		& > * {
+			margin-block: 0;
+		}
+	}
 }
 
 // WP styles for horizontally aligning text within Media & Text blocks
@@ -97,13 +118,10 @@ p img {
 // Base styling for media and text block
 .image-and-text {
 	display: grid;
+	margin-block: 1em;
 
 	.image-and-text__content {
 		margin-left: rem(25);
-	}
-
-	.image-and-text__media {
-		align-self: center;
 	}
 
 	img {


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Fixes the vertical alignment issue for image and text widget.

## Steps to test

1. Go to the admin panel
2. Create a new page using Image and text widget with image position `left`
3. Change the vertical alignment to different options
4. See the changes get applied correctly on the preview

