### PR TITLE
feat: remove role-based authentication check (resolves #906)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -25,9 +25,3 @@
   to = "https://map.wecount.inclusivedesign.ca"
   status = 301
   force = true
-
-[[redirects]]
-  from = "/admin/*"
-  status = 200
-  force = true
-  conditions = {Role = ["admin"]}

--- a/src/_includes/components/footer.njk
+++ b/src/_includes/components/footer.njk
@@ -6,7 +6,4 @@
     {% include 'components/funders.njk' %}
   </div>
   <p class="netlify-notice">Hosted with <a rel="external nofollower noopener" href="https://netlify.com">Netlify</a></p>
-  {% if page.url == "/" -%}
-  <div data-netlify-identity-button></div>
-  {%- endif %}
 </footer>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -37,24 +37,6 @@
     {% block footerScripts %}{% endblock %}
     {% if page.url === "/" %}
     <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
-    <script>
-    netlifyIdentity.on("login", user => {
-      if (user.app_metadata.roles.includes("admin")) {
-        const el = document.querySelector("[data-netlify-identity-button]");
-        const newEl = document.createElement("p");
-        newEl.id = "administration";
-        newEl.className = "has-text-align-center";
-        newEl.innerHTML = "<a href='/admin/'>Administration</a>";
-        el.parentNode.insertBefore(newEl, el);
-      }
-    });
-    netlifyIdentity.on("logout", () => {
-      const el = document.querySelector("#administration");
-      if (el) {
-        el.remove();
-      }
-    });
-    </script>
     {% endif %}
     <script src="/assets/scripts/uio.js" defer></script>
   </body>

--- a/src/assets/styles/components/_components.scss
+++ b/src/assets/styles/components/_components.scss
@@ -5,7 +5,6 @@
 @import "cards";
 @import "expander";
 @import "filter";
-@import "identity";
 @import "idrc-indicator";
 @import "events";
 @import "news-and-initiatives";

--- a/src/assets/styles/components/_identity.scss
+++ b/src/assets/styles/components/_identity.scss
@@ -1,3 +1,0 @@
-[data-netlify-identity-button] {
-	text-align: center;
-}


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This PR removes the role-based redirect away from the admin page for Netlify Identity users without the administration role. Open registration has been disabled for this site so this is no longer necessary and will resolve #906.

## Steps to test

1. Visit /admin/

**Expected behavior:** You are prompted to log in.

## Additional information

Not applicable.

## Related issues

Resolves #906.