### PR TITLE
feat: use lite-youtube-embed for YouTube videos

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -149,6 +149,9 @@ module.exports = function (eleventyConfig) {
 	eleventyConfig.addPassthroughCopy({"src/assets/images": "assets/images"});
 	eleventyConfig.addPassthroughCopy({"src/uploads": "uploads"});
 	eleventyConfig.addPassthroughCopy({"src/assets/scripts": "assets/scripts"});
+	eleventyConfig.addPassthroughCopy({"node_modules/lite-youtube-embed/src/lite-yt-embed.js": "assets/scripts/lite-yt-embed.js"});
+	eleventyConfig.addPassthroughCopy({"node_modules/lite-youtube-embed/src/lite-yt-embed.css": "assets/styles/lite-yt-embed.css"});
+
 	eleventyConfig.addPassthroughCopy({"src/admin/config.yml": "admin/config.yml"});
 	eleventyConfig.addPassthroughCopy({
 		"node_modules/decap-cms/dist/decap-cms.js": "lib/cms/decap-cms.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "html-minifier": "4.0.0",
         "infusion": "4.6.0",
         "linkedom": "0.16.8",
+        "lite-youtube-embed": "0.3.0",
         "markdown-it": "14.0.0",
         "modern-css-reset": "1.4.0",
         "netlify-cms-widget-uuid-v4": "1.1.1",
@@ -12743,6 +12744,11 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/lite-youtube-embed": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/lite-youtube-embed/-/lite-youtube-embed-0.3.0.tgz",
+      "integrity": "sha512-3DUqE1C4s/+a8PVM4ik8anBsmHOW0zUavPyFQWugBulKyQpbZFE+/268Aq/pDNW7hRQJXkXpk4QjdSCpwf7Cvg=="
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "html-minifier": "4.0.0",
     "infusion": "4.6.0",
     "linkedom": "0.16.8",
+    "lite-youtube-embed": "0.3.0",
     "markdown-it": "14.0.0",
     "modern-css-reset": "1.4.0",
     "netlify-cms-widget-uuid-v4": "1.1.1",

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -9,7 +9,9 @@
     {% endif %}
     {% include 'globals/meta.njk' %}
     <link rel="stylesheet" href="/assets/styles/main.css"/>
+    <link rel="stylesheet" href="/assets/styles/lite-yt-embed.css"/>
     <script src="/assets/scripts/main.js" defer></script>
+    <script src="/assets/scripts/lite-yt-embed.js"></script>
     <link rel="preload" href="/lib/infusion/dist/infusion-uio.js" as="script">
 
     <!-- CSS files for UI Options-->

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: main
+  branch: dev
   squash_merges: true
   commit_messages:
     create: 'chore(cms): create "{{path}}"'

--- a/src/assets/styles/base/_base.scss
+++ b/src/assets/styles/base/_base.scss
@@ -104,7 +104,8 @@ button:not(
 .fl-textfieldStepper-button,
 .fl-prefsEditor-showHide,
 .fl-prefsEditor-reset,
-.fl-switchUI-control) {
+.fl-switchUI-control,
+.lty-playbtn) {
 	background-color: $green-light;
 	block-size: rem(54);
 	border: 0;
@@ -124,7 +125,8 @@ button:not(
 .fl-textfieldStepper-button,
 .fl-prefsEditor-showHide,
 .fl-prefsEditor-reset,
-.fl-switchUI-control)::before {
+.fl-switchUI-control,
+.lty-playbtn)::before {
 	block-size: rem(54);
 	border-radius: rem(26);
 	box-shadow: 0 0 0 rem(2) $blue-alt-light inset;

--- a/src/assets/styles/layout/_layout.scss
+++ b/src/assets/styles/layout/_layout.scss
@@ -152,6 +152,10 @@ p img {
 
 .embed--youtube {
 	min-inline-size: 100%;
+
+	lite-youtube {
+		max-inline-size: 100%;
+	}
 }
 
 // Special styling rules for homepage content

--- a/src/shortcodes/youtube.js
+++ b/src/shortcodes/youtube.js
@@ -4,6 +4,6 @@ module.exports = (url) => {
 	const id = getId(url);
 
 	if (id) {
-		return `<figure class="embed--youtube"><iframe class="youtube-player video video--youtube" src="https://www.youtube.com/embed/${id}/" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></figure>`;
+		return `<figure class="embed--youtube"><lite-youtube videoid="${id}" style="background-image: url('https://i.ytimg.com/vi/${id}/hqdefault.jpg');"><a href="https://youtube.com/watch?v=${id}" class="lty-playbtn"><span class="lyt-visually-hidden">Play Video</span></a></lite-youtube></figure>`;
 	}
 };


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This PR uses https://github.com/paulirish/lite-youtube-embed for the YouTube shortcode, which improves performance and privacy for YouTube embeds.

## Steps to test

1. `npm ci`
2. `npm start`

**Expected behavior:** Visit pages with YouTube embeds and test to make sure that they behave as expected.

## Additional information

Not applicable.

## Related issues

Not applicable.