### PR TITLE
fix: expander style issue

### DIFF
--- a/src/assets/styles/base/_base.scss
+++ b/src/assets/styles/base/_base.scss
@@ -126,7 +126,8 @@ button:not(
 .fl-prefsEditor-showHide,
 .fl-prefsEditor-reset,
 .fl-switchUI-control,
-.lty-playbtn)::before {
+.lty-playbtn,
+.expander__toggle)::before {
 	block-size: rem(54);
 	border-radius: rem(26);
 	box-shadow: 0 0 0 rem(2) $blue-alt-light inset;

--- a/src/shortcodes/expander.js
+++ b/src/shortcodes/expander.js
@@ -8,7 +8,7 @@ module.exports = (content, image, alt, title, subtitle) => {
 <img src="${image}" alt="${alt}" width="230" height="230" />
 <h2 id="${slugFilter(title)}" class="expander__title">${title}</h2>
 ${subtitleEl}
-<button aria-expanded="false" aria-labelledby="${slugFilter(title)}">
+<button class="expander__toggle" aria-expanded="false" aria-labelledby="${slugFilter(title)}">
 <svg viewBox="0 0 80 80" fill="currentcolor" aria-hidden="true" focusable="false">
 <rect class="vert" x="30.021" width="20" height="80"></rect>
 <rect y="29.381" width="80" height="20"></rect>


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Add a class for the expander toggle button, and don't apply generic buttons styles on its ::before.

## Steps to test

1. Go to Advisory Panel
2. See the expander buttons have correct style

**Expected behavior:** <!-- What should happen -->

## Additional information

<!-- Please provide any additional information that can help us review your contribution. -->

## Related issues

<!-- If this pull request resolves an issue, please indicate the issue number here, e.g. 'Resolves #42' -->
