### PR TITLE
fix: remove border in default theme

### DIFF
--- a/src/assets/styles/components/_cards.scss
+++ b/src/assets/styles/components/_cards.scss
@@ -10,7 +10,7 @@
 		aspect-ratio: 271 / 476;
 		background-color: $white;
 		background-repeat: no-repeat;
-		border: rem(1) solid;
+		border: rem(1) solid transparent;
 		border-radius: rem(10);
 		box-shadow: 0 rem(4) rem(4) rgba(0 0 0 / 25%);
 		font-family: "Montserrat Alternates", Montserrat, $family-sans-serif;


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Remove border of the cards in default theme, and only apply border in different UIO themes.

## Steps to test

1. Check that cards in main page don't have border
2. Change UIO themes and see cards have border
