### PR TITLE
fix: issue with side navbar items' wordwrap

### DIFF
--- a/src/assets/styles/components/_aside.scss
+++ b/src/assets/styles/components/_aside.scss
@@ -25,7 +25,6 @@ aside {
 					margin-block: 0 rem(23);
 					margin-inline: 0;
 					padding-inline-start: rem(20);
-					word-wrap: break-word;
 
 					&.active {
 						box-shadow: rem(5) 0 0 0 $green-dark inset;


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Items on the side navbar had css rule of `word-wrap: break-word`, which caused unwanted word break on the UI. Remove this rule to fix this issue.
