### PR TITLE
fix: sufficient contrast (resolves #1739)

### DIFF
--- a/src/assets/styles/abstracts/_variables.scss
+++ b/src/assets/styles/abstracts/_variables.scss
@@ -39,7 +39,7 @@ $grey-shade: #c4c4c4;
 $navy: #203149;
 $navy-light: #2e405b;
 $blue-alt: #5c81a9;
-$blue-alt-contrast: #5879a0;
+$blue-alt-contrast: #486484;
 $blue-alt-dark: #4d6b8d;
 $blue-alt-light: #8caabb;
 $blue-grey: #abdde9;


### PR DESCRIPTION
* [ ] This pull request has been linted by running `npm run lint` without errors
* [ ] This pull request has been tested by running `npm run start` and reviewing affected routes
* [ ] This pull request has been built by running `npm run build` without errors
* [ ] This isn't a duplicate of an existing pull request

## Description

Contrast ratio should be at least 4.5:1