### PR TITLE
fix: update video size in RLDN

### DIFF
--- a/src/assets/styles/layout/_layout.css
+++ b/src/assets/styles/layout/_layout.css
@@ -261,7 +261,8 @@ figcaption {
 			inline-size: 100%;
 		}
 
-		.regulating-the-digital-domain .embed--youtube {
+		.regulating-the-digital-domain .embed--youtube,
+		.reguler-le-domaine-numerique .embed--youtube {
 			inline-size: 59%;
 		}
 


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

There was an adjustment to the video size in the Regulating the Digital Domain page in this commit: https://github.com/inclusive-design/wecount.inclusivedesign.ca/commit/817e38f91863bfd4e980f3882271fd77661738f3, however, the change was not including videos in the French page because of how the container class is defined based on page name.

## Steps to test

1. Go to /rldn/
2. See the video size takes about 59% of the screen width, or is the same size as the videos in /rtdd/
